### PR TITLE
Fix icon imports and restore Next.js build

### DIFF
--- a/src/app/(site)/(auth)/forgot-password/page.tsx
+++ b/src/app/(site)/(auth)/forgot-password/page.tsx
@@ -1,7 +1,7 @@
 // Местоположение: /src/app/(auth)/forgot-password/page.tsx
-import { ForgotPasswordForm } from '@/components/auth/ForgotPasswordForm';
+import { ForgotPasswordForm } from '@/components/site/auth/ForgotPasswordForm';
 import Link from 'next/link';
-import Logo from '@/components/icons/Logo';
+import { Logo } from '@/components/shared/icons';
 
 export default function ForgotPasswordPage() {
   return (

--- a/src/app/(site)/(auth)/login/page.tsx
+++ b/src/app/(site)/(auth)/login/page.tsx
@@ -2,12 +2,8 @@
 
 import { useState, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import Logo from '@/components/icons/Logo';
 import Link from 'next/link';
-import TelegramOfficialIcon from '@/components/icons/TelegramOfficialIcon';
-import ClearIcon from '@/components/icons/ClearIcon';
-import { EyeIcon } from '@/components/icons/EyeIcon';
-import { EyeOffIcon } from '@/components/icons/EyeOffIcon';
+import { ClearIcon, EyeIcon, EyeOffIcon, Logo, TelegramOfficialIcon } from '@/components/shared/icons';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');

--- a/src/app/(site)/(auth)/login/verify-code/page.tsx
+++ b/src/app/(site)/(auth)/login/verify-code/page.tsx
@@ -3,8 +3,8 @@
 import { signIn } from 'next-auth/react';
 import { useState, useRef, useEffect, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import Logo from '@/components/icons/Logo';
 import Link from 'next/link';
+import { Logo } from '@/components/shared/icons';
 
 export default function VerifyCodePageWrapper() {
   return (

--- a/src/app/(site)/(auth)/login/verify-request/page.tsx
+++ b/src/app/(site)/(auth)/login/verify-request/page.tsx
@@ -1,6 +1,6 @@
 // Местоположение: src/app/login/verify-request/page.tsx
-import EmailIcon from '@/components/icons/EmailIcon';
 import Link from 'next/link';
+import { EmailIcon } from '@/components/shared/icons';
 
 export default function VerifyRequestPage() {
   return (

--- a/src/app/(site)/(auth)/register/page.tsx
+++ b/src/app/(site)/(auth)/register/page.tsx
@@ -4,14 +4,8 @@
 import { useState, FormEvent, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import { signIn } from 'next-auth/react';
-import Logo from '@/components/icons/Logo';
+import { ClearIcon, EyeIcon, EyeOffIcon, Logo, TelegramOfficialIcon } from '@/components/shared/icons';
 import Link from 'next/link';
-import TelegramOfficialIcon from '@/components/icons/TelegramOfficialIcon';
-import { EyeIcon } from '@/components/icons/EyeIcon';
-import { EyeOffIcon } from '@/components/icons/EyeOffIcon';
-// --- НАЧАЛО ИЗМЕНЕНИЙ: Импортируем иконку крестика ---
-import ClearIcon from '@/components/icons/ClearIcon';
-// --- КОНЕЦ ИЗМЕНЕНИЙ ---
 
 const validateEmail = (email: string) => {
   const re =

--- a/src/app/(site)/(auth)/reset-password/page.tsx
+++ b/src/app/(site)/(auth)/reset-password/page.tsx
@@ -1,8 +1,8 @@
 // Местоположение: /src/app/(auth)/reset-password/page.tsx
-import { ResetPasswordForm } from '@/components/auth/ResetPasswordForm';
+import { ResetPasswordForm } from '@/components/site/auth/ResetPasswordForm';
 import Link from 'next/link';
 import prisma from '@/lib/prisma';
-import Logo from '@/components/icons/Logo';
+import { Logo } from '@/components/shared/icons';
 
 const MessageDisplay = ({
   title,

--- a/src/app/(site)/loading.tsx
+++ b/src/app/(site)/loading.tsx
@@ -8,7 +8,7 @@
 
 import { useEffect } from 'react';
 import { usePathname } from 'next/navigation'; // Инструмент, чтобы узнать текущий URL
-import ShortLogo from '@/components/icons/ShortLogo'; // Наш брендированный логотип
+import { ShortLogo } from '@/components/shared/icons'; // Наш брендированный логотип
 
 export default function Loading() {
   // "Смотрим, на какой сцене мы выступаем". Получаем текущий путь, например, "/" или "/catalog".

--- a/src/app/(site)/profile/ProfileClient.tsx
+++ b/src/app/(site)/profile/ProfileClient.tsx
@@ -5,12 +5,12 @@ import type { User } from '@prisma/client';
 import { useRouter } from 'next/navigation';
 
 import { updateUserProfile, updateUserPassword } from './actions';
-import ProfileHeader from '@/components/profile/ProfileHeader';
-import EditProfileForm from '@/components/profile/EditProfileForm';
-import EditPasswordForm from '@/components/profile/EditPasswordForm';
+import EditPasswordForm from '@/components/site/profile/EditPasswordForm';
+import EditProfileForm from '@/components/site/profile/EditProfileForm';
+import ProfileHeader from '@/components/site/profile/ProfileHeader';
+import ProfileInfoBlock from '@/components/site/profile/ProfileInfoBlock';
+import VerificationModal from '@/components/shared/modals/VerificationModal'; // <-- ШАГ 1: Импортируем модальное окно
 import SignOutButton from './SignOutButton';
-import ProfileInfoBlock from '@/components/profile/ProfileInfoBlock';
-import VerificationModal from '@/components/auth/VerificationModal'; // <-- ШАГ 1: Импортируем модальное окно
 
 type DecryptedUser = User & {
   name: string;
@@ -131,6 +131,7 @@ export default function ProfileClient({
       <VerificationModal
         isOpen={isVerificationModalOpen}
         onClose={() => setIsVerificationModalOpen(false)}
+        email={user.email}
       />
 
       <div className="space-y-0 pb-8 pt-6">

--- a/src/app/(site)/verify-email/page.tsx
+++ b/src/app/(site)/verify-email/page.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useState, Suspense } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
-import Logo from '@/components/icons/Logo';
+import { Logo } from '@/components/shared/icons';
 
 function VerifyEmailContent() {
   const searchParams = useSearchParams();

--- a/src/components/AvatarPlaceholder.tsx
+++ b/src/components/AvatarPlaceholder.tsx
@@ -1,7 +1,7 @@
 // Местоположение: /src/components/AvatarPlaceholder.tsx
 // Этот компонент отвечает за отображение "заглушки" для аватара.
 
-import ShortLogo from './icons/ShortLogo';
+import { ShortLogo } from './shared/icons';
 
 export default function AvatarPlaceholder() {
   return (

--- a/src/components/ConditionalHeader.tsx
+++ b/src/components/ConditionalHeader.tsx
@@ -2,8 +2,8 @@
 
 import { usePathname } from 'next/navigation';
 import Header from '@/components/Header';
-import ProductPageHeader from '@/components/layout/ProductPageHeader';
 import HybridHeader from './HybridHeader';
+import ProductPageHeader from '@/components/shared/layout/ProductPageHeader';
 import { useAppStore } from '@/store/useAppStore';
 
 export default function ConditionalHeader() {

--- a/src/components/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
-import { ArrowRightIcon } from './icons/ArrowRightIcon';
+import { ArrowRightIcon } from './shared/icons';
 
 export default function CookieConsentBanner() {
   const [isVisible, setIsVisible] = useState(false);

--- a/src/components/FloatingLogoButton.tsx
+++ b/src/components/FloatingLogoButton.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import ShortLogo from './icons/ShortLogo';
+import { ShortLogo } from './shared/icons';
 import { useFooter } from '@/context/FooterContext';
 
 interface FloatingLogoButtonProps {

--- a/src/components/FloatingMenuOverlay/AuthenticatedView.tsx
+++ b/src/components/FloatingMenuOverlay/AuthenticatedView.tsx
@@ -3,9 +3,7 @@
 import React, { useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
-import SettingsIcon from '../icons/SettingsIcon';
-import ShortLogo from '../icons/ShortLogo';
-import AdminIcon from '../icons/AdminIcon';
+import { AdminIcon, SettingsIcon, ShortLogo } from '../shared/icons';
 import AvatarPlaceholder from '../AvatarPlaceholder';
 
 interface UserSession {

--- a/src/components/FloatingMenuOverlay/CartSummary.tsx
+++ b/src/components/FloatingMenuOverlay/CartSummary.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import CartIcon from '../icons/CartIcon';
-import ChevronIcon from '../icons/ChevronIcon';
+import { CartIcon, ChevronIcon } from '../shared/icons';
 
 const CartSummary = () => {
   const [isCartOpen, setIsCartOpen] = useState(false);

--- a/src/components/FloatingMenuOverlay/DeliveryStatus.tsx
+++ b/src/components/FloatingMenuOverlay/DeliveryStatus.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import TruckIcon from '../icons/TruckIcon';
-import ChevronIcon from '../icons/ChevronIcon';
+import { ChevronIcon, TruckIcon } from '../shared/icons';
 import StatusStep from './StatusStep';
 
 const DeliveryStatus = () => {

--- a/src/components/FloatingMenuOverlay/MenuHeader.tsx
+++ b/src/components/FloatingMenuOverlay/MenuHeader.tsx
@@ -3,9 +3,7 @@
 import React, { useState } from 'react';
 import Link from 'next/link';
 import { useAppStore } from '@/store/useAppStore';
-import Logo from '../icons/Logo';
-import SearchIcon from '../icons/SearchIcon';
-import CloseIcon from '../icons/CloseIcon';
+import { CloseIcon, Logo, SearchIcon } from '../shared/icons';
 
 interface MenuHeaderProps {
   onClose: () => void;

--- a/src/components/FloatingMenuOverlay/index.tsx
+++ b/src/components/FloatingMenuOverlay/index.tsx
@@ -12,9 +12,8 @@ import MenuButton from './MenuButton';
 import ShopNavigation from './ShopNavigation';
 import InfoLinks from './InfoLinks';
 import MenuFooter from './MenuFooter';
-import HeartIcon from '../icons/HeartIcon';
-import ReceiptIcon from '../icons/ReceiptIcon';
-import VerificationModal from '../modals/VerificationModal'; // <-- ШАГ 1: Импортируем модальное окно
+import { HeartIcon, ReceiptIcon } from '../shared/icons';
+import VerificationModal from '../shared/modals/VerificationModal'; // <-- ШАГ 1: Импортируем модальное окно
 
 interface FloatingMenuOverlayProps {
   isOpen: boolean;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,10 +2,7 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import Logo from './icons/Logo';
-import CloseIcon from './icons/CloseIcon';
-import BurgerIcon from './icons/BurgerIcon';
-import SearchIcon from './icons/SearchIcon';
+import { BurgerIcon, CloseIcon, Logo, SearchIcon } from './shared/icons';
 import { useAppStore } from '@/store/useAppStore';
 
 interface HeaderProps {

--- a/src/components/ImagePlaceholder.tsx
+++ b/src/components/ImagePlaceholder.tsx
@@ -1,5 +1,5 @@
 // Местоположение: src/components/ImagePlaceholder.tsx
-import ShortLogo from './icons/ShortLogo';
+import { ShortLogo } from './shared/icons';
 
 // Этот компонент отвечает за серую подложку во время загрузки фото
 export default function ImagePlaceholder() {

--- a/src/components/Preloader.tsx
+++ b/src/components/Preloader.tsx
@@ -1,4 +1,4 @@
-import ShortLogo from './icons/ShortLogo';
+import { ShortLogo } from './shared/icons';
 
 interface PreloaderProps {
   top: number;

--- a/src/components/ProductDetails.tsx
+++ b/src/components/ProductDetails.tsx
@@ -2,20 +2,20 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Prisma } from '@prisma/client';
-import MobileProductGallery from './product-details/MobileProductGallery';
-import DesktopProductGallery from './product-details/DesktopProductGallery';
-import ProductHeader from './product-details/ProductHeader';
-import AddToCartButton from './product-details/AddToCartButton';
-import SizeSelector from './product-details/SizeSelector';
-import SizeChart from './product-details/SizeChart';
-import ProductAttributes from './product-details/ProductAttributes';
-import BottomSheet from '@/components/ui/BottomSheet';
-import SizeGuideContent from './product-details/SizeGuideContent';
-import DesktopActionButtons from './product-details/DesktopActionButtons';
-import ArrowStep1 from '@/components/illustrations/ArrowStep1';
 import Image from 'next/image';
-import ProductActions from './product-details/ProductActions';
+import { Prisma } from '@prisma/client';
+import ArrowStep1 from '@/components/illustrations/ArrowStep1';
+import DesktopActionButtons from '@/components/site/product/DesktopActionButtons';
+import DesktopProductGallery from '@/components/site/product/DesktopProductGallery';
+import MobileProductGallery from '@/components/site/product/MobileProductGallery';
+import ProductActions from '@/components/site/product/ProductActions';
+import ProductAttributes from '@/components/site/product/ProductAttributes';
+import ProductHeader from '@/components/site/product/ProductHeader';
+import SizeChart from '@/components/site/product/SizeChart';
+import SizeGuideContent from '@/components/site/product/SizeGuideContent';
+import SizeSelector from '@/components/site/product/SizeSelector';
+import AddToCartButton from '@/components/site/product/AddToCartButton';
+import BottomSheet from '@/components/shared/ui/BottomSheet';
 
 // ... (компоненты CountdownTimer и MobileSizeGuideWithAccordion остаются без изменений) ...
 const CountdownTimer = ({

--- a/src/components/admin/AdminHeader.tsx
+++ b/src/components/admin/AdminHeader.tsx
@@ -3,10 +3,9 @@
 import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import ShortLogo from '@/components/icons/ShortLogo';
+import { ChevronIcon, ShortLogo } from '@/components/shared/icons';
 import { useAppStore } from '@/store/useAppStore';
 import { signOut } from 'next-auth/react';
-import ChevronIcon from '../icons/ChevronIcon';
 
 // Определяем структуру ссылок для навигации
 const adminNavLinks = [

--- a/src/components/admin/product-table/ProductSizeRow.tsx
+++ b/src/components/admin/product-table/ProductSizeRow.tsx
@@ -6,10 +6,7 @@ import type { Prisma } from '@prisma/client';
 import toast from 'react-hot-toast';
 import { Copy, Check } from 'lucide-react';
 
-import { PencilIcon } from '@/components/icons/PencilIcon';
-import { CheckIcon } from '@/components/icons/CheckIcon';
-import { XMarkIcon } from '@/components/icons/XMarkIcon';
-import { SpinnerIcon } from '@/components/icons/SpinnerIcon';
+import { CheckIcon, PencilIcon, SpinnerIcon, XMarkIcon } from '@/components/shared/icons';
 
 const useCopyToClipboard = () => {
   const [isCopied, setIsCopied] = useState(false);

--- a/src/components/shared/layout/CatalogHeaderController.tsx
+++ b/src/components/shared/layout/CatalogHeaderController.tsx
@@ -3,12 +3,12 @@
 
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import Header from '@/components/Header';
-import StickyHeader from './StickyHeader';
-import CategoryFilter from '../CategoryFilter';
-import StickyCategoryFilter from './StickyCategoryFilter';
-import CatalogContent from '../CatalogContent';
+import CatalogContent from '@/components/CatalogContent';
+import CategoryFilter from '@/components/CategoryFilter';
 import { useAppStore } from '@/store/useAppStore';
 import { ProductWithInfo } from '@/lib/types';
+import StickyCategoryFilter from './StickyCategoryFilter';
+import StickyHeader from './StickyHeader';
 
 interface Category {
   id: string;

--- a/src/components/shared/layout/ProductPageHeader.tsx
+++ b/src/components/shared/layout/ProductPageHeader.tsx
@@ -3,8 +3,7 @@
 
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import HeartIcon from '@/components/icons/HeartIcon';
-import ShareIcon from '@/components/icons/ShareIcon';
+import { HeartIcon, ShareIcon } from '@/components/shared/icons';
 
 const BackArrowIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg

--- a/src/components/shared/layout/StickyCategoryFilter.tsx
+++ b/src/components/shared/layout/StickyCategoryFilter.tsx
@@ -1,7 +1,7 @@
 // Местоположение: src/components/layout/StickyCategoryFilter.tsx
 'use client';
 
-import CategoryFilter from '../CategoryFilter';
+import CategoryFilter from '@/components/CategoryFilter';
 
 // --- НАЧАЛО ИЗМЕНЕНИЙ: Обновляем "должностную инструкцию" (Props) ---
 // Добавляем все недостающие "пункты", чтобы соответствовать CatalogHeaderController.

--- a/src/components/shared/layout/StickyHeader.tsx
+++ b/src/components/shared/layout/StickyHeader.tsx
@@ -3,11 +3,8 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import Logo from '../icons/Logo';
-import CloseIcon from '../icons/CloseIcon';
-import BurgerIcon from '../icons/BurgerIcon';
-import SearchIcon from '../icons/SearchIcon';
-import DesktopNav from '../header/DesktopNav';
+import { BurgerIcon, CloseIcon, Logo, SearchIcon } from '../icons';
+import DesktopNav from '@/components/site/layout/DesktopNav';
 import { useAppStore } from '@/store/useAppStore';
 
 interface StickyHeaderProps {

--- a/src/components/shared/layout/StickyProductPageHeader.tsx
+++ b/src/components/shared/layout/StickyProductPageHeader.tsx
@@ -3,8 +3,7 @@
 
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import CartIcon from '@/components/icons/CartIcon'; // Импорт пока оставим, вдруг понадобится
-import HeartIcon from '@/components/icons/HeartIcon';
+import { CartIcon, HeartIcon } from '@/components/shared/icons';
 
 const BackArrowIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg

--- a/src/components/shared/modals/VerificationModal.tsx
+++ b/src/components/shared/modals/VerificationModal.tsx
@@ -5,8 +5,8 @@ import { useRouter } from 'next/navigation'; // <-- ШАГ 1: Импортиру
 import { signIn } from 'next-auth/react';
 // useAppStore больше не нужен для обновления, но может понадобиться для чего-то еще, пока оставим
 import { useAppStore } from '@/store/useAppStore';
+import { CloseIcon } from '../icons';
 import CodeInput from './CodeInput';
-import CloseIcon from '../icons/CloseIcon';
 
 interface VerificationModalProps {
   isOpen: boolean;

--- a/src/components/shared/ui/BottomSheet.tsx
+++ b/src/components/shared/ui/BottomSheet.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import CloseIcon from '@/components/icons/CloseIcon';
+import { CloseIcon } from '@/components/shared/icons';
 
 interface BottomSheetProps {
   isOpen: boolean;

--- a/src/components/site/auth/ForgotPasswordForm.tsx
+++ b/src/components/site/auth/ForgotPasswordForm.tsx
@@ -4,7 +4,7 @@
 import { useState, FormEvent, useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
 import toast from 'react-hot-toast';
-import ClearIcon from '@/components/icons/ClearIcon'; // Импортируем иконку
+import { ClearIcon } from '@/components/shared/icons'; // Импортируем иконку
 
 export function ForgotPasswordForm() {
   const searchParams = useSearchParams();

--- a/src/components/site/auth/ResetPasswordForm.tsx
+++ b/src/components/site/auth/ResetPasswordForm.tsx
@@ -4,7 +4,7 @@
 import { useState, FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import toast from 'react-hot-toast';
-import ClearIcon from '@/components/icons/ClearIcon';
+import { ClearIcon } from '@/components/shared/icons';
 
 export function ResetPasswordForm({ token }: { token: string }) {
   const router = useRouter();

--- a/src/components/site/auth/VerificationModal.tsx
+++ b/src/components/site/auth/VerificationModal.tsx
@@ -2,8 +2,8 @@
 
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import { CloseIcon } from '@/components/shared/icons';
 import CodeInput from './CodeInput';
-import CloseIcon from '../icons/CloseIcon';
 
 interface VerificationModalProps {
   isOpen: boolean;

--- a/src/components/site/layout/DesktopNav.tsx
+++ b/src/components/site/layout/DesktopNav.tsx
@@ -1,11 +1,9 @@
 // Местоположение: src/components/header/DesktopNav.tsx
 import Link from 'next/link';
-import SearchIcon from '../icons/SearchIcon';
-import CartIcon from '../icons/CartIcon';
 import { NAV_LINKS } from '@/config/navigation';
 // --- НАЧАЛО ИЗМЕНЕНИЙ ---
 import { Session } from 'next-auth'; // Импортируем тип Session
-import UserIcon from '../icons/UserIcon';
+import { CartIcon, SearchIcon, UserIcon } from '@/components/shared/icons';
 // --- КОНЕЦ ИЗМЕНЕНИЙ ---
 
 // --- НАЧАЛО ИЗМЕНЕНИЙ ---

--- a/src/components/site/product/AddToCartButton.tsx
+++ b/src/components/site/product/AddToCartButton.tsx
@@ -1,7 +1,7 @@
 // Местоположение: src/components/product-details/AddToCartButton.tsx
 'use client';
 
-import Button from '@/components/ui/Button';
+import { Button } from '@/components/shared/ui';
 
 // --- Иконки для счетчика ---
 const MinusIcon = (props: React.SVGProps<SVGSVGElement>) => (

--- a/src/components/site/product/DesktopActionButtons.tsx
+++ b/src/components/site/product/DesktopActionButtons.tsx
@@ -4,7 +4,7 @@
 // Убираем ненужные хуки для отслеживания скролла
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import HeartIcon from '../icons/HeartIcon';
+import { HeartIcon } from '@/components/shared/icons';
 
 const BackArrowIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg

--- a/src/components/site/product/DesktopSizeAndCartButton.tsx
+++ b/src/components/site/product/DesktopSizeAndCartButton.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import { useState, useRef, useEffect } from 'react';
-import Button from '@/components/ui/Button';
+import { Button } from '@/components/shared/ui';
 
 // --- Иконки для счетчика ---
 const MinusIcon = (props: React.SVGProps<SVGSVGElement>) => (

--- a/src/components/site/product/ProductAttributes.tsx
+++ b/src/components/site/product/ProductAttributes.tsx
@@ -3,9 +3,8 @@
 
 import { useState, useRef, useEffect } from 'react';
 // --- НАЧАЛО ИЗМЕНЕНИЙ: Исправляем импорт CopyIcon ---
-import CopyIcon from '@/components/icons/CopyIcon'; // Импорт по умолчанию
+import { CheckIcon, CopyIcon } from '@/components/shared/icons';
 import { useAppStore } from '@/store/useAppStore';
-import { CheckIcon } from '@/components/icons/CheckIcon'; // Именованный импорт
 // --- КОНЕЦ ИЗМЕНЕНИЙ ---
 
 const ChevronIcon = ({ isOpen }: { isOpen: boolean }) => (

--- a/src/components/site/product/ProductHeader.tsx
+++ b/src/components/site/product/ProductHeader.tsx
@@ -1,8 +1,8 @@
 // Местоположение: src/components/product-details/ProductHeader.tsx
 'use client';
 
+import { ShortLogo } from '@/components/shared/icons';
 import { formatPrice } from '@/utils/formatPrice';
-import ShortLogo from '../icons/ShortLogo';
 
 interface ProductHeaderProps {
   name: string;

--- a/src/components/site/product/SizeSelector.tsx
+++ b/src/components/site/product/SizeSelector.tsx
@@ -1,8 +1,8 @@
 // Местоположение: src/components/product-details/SizeSelector.tsx
 'use client';
 
+import { HeartIcon } from '@/components/shared/icons';
 import LowStockBadge from './LowStockBadge';
-import HeartIcon from '../icons/HeartIcon';
 
 interface InventoryItem {
   size: { id: string; value: string };

--- a/src/components/site/profile/ProfileHeader.tsx
+++ b/src/components/site/profile/ProfileHeader.tsx
@@ -5,8 +5,7 @@ import type { User } from '@prisma/client'; // <-- ИЗМЕНЕНО: Возвр�
 import Image from 'next/image';
 
 import AvatarPlaceholder from '@/components/AvatarPlaceholder';
-import ShortLogo from '@/components/icons/ShortLogo';
-import SettingsIcon from '../icons/SettingsIcon';
+import { SettingsIcon, ShortLogo } from '@/components/shared/icons';
 // --- УДАЛЕНО: Убираем импорт серверной утилиты ---
 // import { decrypt } from '@/lib/encryption';
 

--- a/src/components/site/profile/ProfileInfoBlock.tsx
+++ b/src/components/site/profile/ProfileInfoBlock.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import SettingsIcon from '../icons/SettingsIcon';
+import { SettingsIcon } from '@/components/shared/icons';
 
 interface ProfileInfoBlockProps {
   title: string;


### PR DESCRIPTION
## Summary
- update application pages and feature components to import icons from the new shared barrel exports
- point product and auth modules to their feature-based folders and adjust shared UI imports
- wire the profile verification modal through the shared modal implementation and ensure required props are provided

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e54a8d2de4833180c273f216ab712d