### PR TITLE
Harden env handling for encryption and Telegram integrations

### DIFF
--- a/src/app/(site)/(auth)/forgot-password/page.tsx
+++ b/src/app/(site)/(auth)/forgot-password/page.tsx
@@ -1,7 +1,7 @@
 // Местоположение: /src/app/(auth)/forgot-password/page.tsx
-import { ForgotPasswordForm } from '@/components/auth/ForgotPasswordForm';
+import { ForgotPasswordForm } from '@/components/site/auth/ForgotPasswordForm';
 import Link from 'next/link';
-import Logo from '@/components/icons/Logo';
+import { Logo } from '@/components/shared/icons';
 
 export default function ForgotPasswordPage() {
   return (

--- a/src/app/(site)/(auth)/login/page.tsx
+++ b/src/app/(site)/(auth)/login/page.tsx
@@ -2,12 +2,8 @@
 
 import { useState, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import Logo from '@/components/icons/Logo';
 import Link from 'next/link';
-import TelegramOfficialIcon from '@/components/icons/TelegramOfficialIcon';
-import ClearIcon from '@/components/icons/ClearIcon';
-import { EyeIcon } from '@/components/icons/EyeIcon';
-import { EyeOffIcon } from '@/components/icons/EyeOffIcon';
+import { ClearIcon, EyeIcon, EyeOffIcon, Logo, TelegramOfficialIcon } from '@/components/shared/icons';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');

--- a/src/app/(site)/(auth)/login/verify-code/page.tsx
+++ b/src/app/(site)/(auth)/login/verify-code/page.tsx
@@ -3,8 +3,8 @@
 import { signIn } from 'next-auth/react';
 import { useState, useRef, useEffect, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import Logo from '@/components/icons/Logo';
 import Link from 'next/link';
+import { Logo } from '@/components/shared/icons';
 
 export default function VerifyCodePageWrapper() {
   return (

--- a/src/app/(site)/(auth)/login/verify-request/page.tsx
+++ b/src/app/(site)/(auth)/login/verify-request/page.tsx
@@ -1,6 +1,6 @@
 // Местоположение: src/app/login/verify-request/page.tsx
-import EmailIcon from '@/components/icons/EmailIcon';
 import Link from 'next/link';
+import { EmailIcon } from '@/components/shared/icons';
 
 export default function VerifyRequestPage() {
   return (

--- a/src/app/(site)/(auth)/register/page.tsx
+++ b/src/app/(site)/(auth)/register/page.tsx
@@ -4,14 +4,8 @@
 import { useState, FormEvent, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import { signIn } from 'next-auth/react';
-import Logo from '@/components/icons/Logo';
+import { ClearIcon, EyeIcon, EyeOffIcon, Logo, TelegramOfficialIcon } from '@/components/shared/icons';
 import Link from 'next/link';
-import TelegramOfficialIcon from '@/components/icons/TelegramOfficialIcon';
-import { EyeIcon } from '@/components/icons/EyeIcon';
-import { EyeOffIcon } from '@/components/icons/EyeOffIcon';
-// --- НАЧАЛО ИЗМЕНЕНИЙ: Импортируем иконку крестика ---
-import ClearIcon from '@/components/icons/ClearIcon';
-// --- КОНЕЦ ИЗМЕНЕНИЙ ---
 
 const validateEmail = (email: string) => {
   const re =

--- a/src/app/(site)/(auth)/reset-password/page.tsx
+++ b/src/app/(site)/(auth)/reset-password/page.tsx
@@ -1,8 +1,8 @@
 // Местоположение: /src/app/(auth)/reset-password/page.tsx
-import { ResetPasswordForm } from '@/components/auth/ResetPasswordForm';
+import { ResetPasswordForm } from '@/components/site/auth/ResetPasswordForm';
 import Link from 'next/link';
 import prisma from '@/lib/prisma';
-import Logo from '@/components/icons/Logo';
+import { Logo } from '@/components/shared/icons';
 
 const MessageDisplay = ({
   title,

--- a/src/app/(site)/loading.tsx
+++ b/src/app/(site)/loading.tsx
@@ -8,7 +8,7 @@
 
 import { useEffect } from 'react';
 import { usePathname } from 'next/navigation'; // Инструмент, чтобы узнать текущий URL
-import ShortLogo from '@/components/icons/ShortLogo'; // Наш брендированный логотип
+import { ShortLogo } from '@/components/shared/icons'; // Наш брендированный логотип
 
 export default function Loading() {
   // "Смотрим, на какой сцене мы выступаем". Получаем текущий путь, например, "/" или "/catalog".

--- a/src/app/(site)/profile/ProfileClient.tsx
+++ b/src/app/(site)/profile/ProfileClient.tsx
@@ -5,12 +5,12 @@ import type { User } from '@prisma/client';
 import { useRouter } from 'next/navigation';
 
 import { updateUserProfile, updateUserPassword } from './actions';
-import ProfileHeader from '@/components/profile/ProfileHeader';
-import EditProfileForm from '@/components/profile/EditProfileForm';
-import EditPasswordForm from '@/components/profile/EditPasswordForm';
+import EditPasswordForm from '@/components/site/profile/EditPasswordForm';
+import EditProfileForm from '@/components/site/profile/EditProfileForm';
+import ProfileHeader from '@/components/site/profile/ProfileHeader';
+import ProfileInfoBlock from '@/components/site/profile/ProfileInfoBlock';
+import VerificationModal from '@/components/shared/modals/VerificationModal'; // <-- ШАГ 1: Импортируем модальное окно
 import SignOutButton from './SignOutButton';
-import ProfileInfoBlock from '@/components/profile/ProfileInfoBlock';
-import VerificationModal from '@/components/auth/VerificationModal'; // <-- ШАГ 1: Импортируем модальное окно
 
 type DecryptedUser = User & {
   name: string;
@@ -131,6 +131,7 @@ export default function ProfileClient({
       <VerificationModal
         isOpen={isVerificationModalOpen}
         onClose={() => setIsVerificationModalOpen(false)}
+        email={user.email}
       />
 
       <div className="space-y-0 pb-8 pt-6">

--- a/src/app/(site)/verify-email/page.tsx
+++ b/src/app/(site)/verify-email/page.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useState, Suspense } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
-import Logo from '@/components/icons/Logo';
+import { Logo } from '@/components/shared/icons';
 
 function VerifyEmailContent() {
   const searchParams = useSearchParams();

--- a/src/app/api/auth/create-login-token/route.ts
+++ b/src/app/api/auth/create-login-token/route.ts
@@ -7,6 +7,13 @@ import { addMinutes } from 'date-fns';
 // Эта функция - наша "Касса", выдающая уникальные билеты.
 export async function GET() {
   try {
+    if (process.env.NEXT_PHASE === 'phase-production-build') {
+      console.log(
+        '⚠️ create-login-token: пропускаем обращение к базе во время сборки.',
+      );
+      return NextResponse.json({ token: 'build-token-placeholder' });
+    }
+
     // 1. Генерируем криптографически случайный, безопасный номер для "билета".
     const token = crypto.randomBytes(32).toString('hex');
 

--- a/src/app/api/support-form/route.ts
+++ b/src/app/api/support-form/route.ts
@@ -2,7 +2,7 @@
 
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
-import { supportBot } from '@/lib/telegram'; // <-- ИЗМЕНЕНО: Импортируем наш новый Telegraf-бот
+import { getSupportBot } from '@/lib/telegram'; // <-- ИЗМЕНЕНО: Импортируем ленивый доступ к Telegraf-боту
 import { Markup } from 'telegraf'; // <-- ДОБАВЛЕНО: Импортируем хелпер для клавиатур
 
 interface SupportFormRequestBody {
@@ -32,6 +32,8 @@ async function notifyAgents(ticket: {
     console.warn(`Нет агентов для уведомления о тикете ${ticket.id}`);
     return;
   }
+
+  const supportBot = getSupportBot();
 
   const messageText = `
 📬 **Новое обращение!** (на ${ticket.assignedEmail || 'support'})

--- a/src/app/api/telegram-webhook/route.ts
+++ b/src/app/api/telegram-webhook/route.ts
@@ -2,7 +2,7 @@
 // МОДЕРНИЗИРОВАННАЯ ВЕРСИЯ
 
 import { NextResponse } from 'next/server';
-import { clientBot } from '@/lib/telegram'; // <-- ИЗМЕНЕНО: Импортируем наш Telegraf-бот
+import { getClientBot } from '@/lib/telegram'; // <-- ИЗМЕНЕНО: Импортируем ленивый доступ к Telegraf-боту
 
 const webhookSecret = process.env.TELEGRAM_WEBHOOK_SECRET;
 
@@ -27,6 +27,7 @@ export async function POST(request: Request) {
     // 3. Передаем все обновление на обработку в Telegraf.
     // Telegraf сам разберется, что это было, и вызовет нужный обработчик,
     // который мы определим в /lib/telegram.ts
+    const clientBot = getClientBot();
     await clientBot.handleUpdate(body);
 
     // 4. Отвечаем Telegram, что все в порядке.

--- a/src/app/api/webhooks/telegram/support/route.ts
+++ b/src/app/api/webhooks/telegram/support/route.ts
@@ -2,7 +2,7 @@
 // Новая, единственно верная точка входа для вебхуков Бота Поддержки.
 
 import { NextResponse } from 'next/server';
-import { supportBot } from '@/lib/telegram';
+import { getSupportBot } from '@/lib/telegram';
 
 export async function POST(request: Request) {
   try {
@@ -19,6 +19,7 @@ export async function POST(request: Request) {
     // 3. Главная магия Telegraf: передаем все обновление на обработку.
     // Telegraf сам разберется, что это было - команда, нажатие кнопки или сообщение,
     // и вызовет нужный обработчик, который мы определим позже.
+    const supportBot = getSupportBot();
     await supportBot.handleUpdate(body);
 
     // 4. Отвечаем Telegram, что все в порядке, чтобы он не слал обновление повторно.

--- a/src/components/AvatarPlaceholder.tsx
+++ b/src/components/AvatarPlaceholder.tsx
@@ -1,7 +1,7 @@
 // Местоположение: /src/components/AvatarPlaceholder.tsx
 // Этот компонент отвечает за отображение "заглушки" для аватара.
 
-import ShortLogo from './icons/ShortLogo';
+import { ShortLogo } from './shared/icons';
 
 export default function AvatarPlaceholder() {
   return (

--- a/src/components/ConditionalHeader.tsx
+++ b/src/components/ConditionalHeader.tsx
@@ -2,8 +2,8 @@
 
 import { usePathname } from 'next/navigation';
 import Header from '@/components/Header';
-import ProductPageHeader from '@/components/layout/ProductPageHeader';
 import HybridHeader from './HybridHeader';
+import ProductPageHeader from '@/components/shared/layout/ProductPageHeader';
 import { useAppStore } from '@/store/useAppStore';
 
 export default function ConditionalHeader() {

--- a/src/components/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
-import { ArrowRightIcon } from './icons/ArrowRightIcon';
+import { ArrowRightIcon } from './shared/icons';
 
 export default function CookieConsentBanner() {
   const [isVisible, setIsVisible] = useState(false);

--- a/src/components/FloatingLogoButton.tsx
+++ b/src/components/FloatingLogoButton.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import ShortLogo from './icons/ShortLogo';
+import { ShortLogo } from './shared/icons';
 import { useFooter } from '@/context/FooterContext';
 
 interface FloatingLogoButtonProps {

--- a/src/components/FloatingMenuOverlay/AuthenticatedView.tsx
+++ b/src/components/FloatingMenuOverlay/AuthenticatedView.tsx
@@ -3,9 +3,7 @@
 import React, { useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
-import SettingsIcon from '../icons/SettingsIcon';
-import ShortLogo from '../icons/ShortLogo';
-import AdminIcon from '../icons/AdminIcon';
+import { AdminIcon, SettingsIcon, ShortLogo } from '../shared/icons';
 import AvatarPlaceholder from '../AvatarPlaceholder';
 
 interface UserSession {

--- a/src/components/FloatingMenuOverlay/CartSummary.tsx
+++ b/src/components/FloatingMenuOverlay/CartSummary.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import CartIcon from '../icons/CartIcon';
-import ChevronIcon from '../icons/ChevronIcon';
+import { CartIcon, ChevronIcon } from '../shared/icons';
 
 const CartSummary = () => {
   const [isCartOpen, setIsCartOpen] = useState(false);

--- a/src/components/FloatingMenuOverlay/DeliveryStatus.tsx
+++ b/src/components/FloatingMenuOverlay/DeliveryStatus.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import TruckIcon from '../icons/TruckIcon';
-import ChevronIcon from '../icons/ChevronIcon';
+import { ChevronIcon, TruckIcon } from '../shared/icons';
 import StatusStep from './StatusStep';
 
 const DeliveryStatus = () => {

--- a/src/components/FloatingMenuOverlay/MenuHeader.tsx
+++ b/src/components/FloatingMenuOverlay/MenuHeader.tsx
@@ -3,9 +3,7 @@
 import React, { useState } from 'react';
 import Link from 'next/link';
 import { useAppStore } from '@/store/useAppStore';
-import Logo from '../icons/Logo';
-import SearchIcon from '../icons/SearchIcon';
-import CloseIcon from '../icons/CloseIcon';
+import { CloseIcon, Logo, SearchIcon } from '../shared/icons';
 
 interface MenuHeaderProps {
   onClose: () => void;

--- a/src/components/FloatingMenuOverlay/index.tsx
+++ b/src/components/FloatingMenuOverlay/index.tsx
@@ -12,9 +12,8 @@ import MenuButton from './MenuButton';
 import ShopNavigation from './ShopNavigation';
 import InfoLinks from './InfoLinks';
 import MenuFooter from './MenuFooter';
-import HeartIcon from '../icons/HeartIcon';
-import ReceiptIcon from '../icons/ReceiptIcon';
-import VerificationModal from '../modals/VerificationModal'; // <-- ШАГ 1: Импортируем модальное окно
+import { HeartIcon, ReceiptIcon } from '../shared/icons';
+import VerificationModal from '../shared/modals/VerificationModal'; // <-- ШАГ 1: Импортируем модальное окно
 
 interface FloatingMenuOverlayProps {
   isOpen: boolean;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,10 +2,7 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import Logo from './icons/Logo';
-import CloseIcon from './icons/CloseIcon';
-import BurgerIcon from './icons/BurgerIcon';
-import SearchIcon from './icons/SearchIcon';
+import { BurgerIcon, CloseIcon, Logo, SearchIcon } from './shared/icons';
 import { useAppStore } from '@/store/useAppStore';
 
 interface HeaderProps {

--- a/src/components/ImagePlaceholder.tsx
+++ b/src/components/ImagePlaceholder.tsx
@@ -1,5 +1,5 @@
 // Местоположение: src/components/ImagePlaceholder.tsx
-import ShortLogo from './icons/ShortLogo';
+import { ShortLogo } from './shared/icons';
 
 // Этот компонент отвечает за серую подложку во время загрузки фото
 export default function ImagePlaceholder() {

--- a/src/components/Preloader.tsx
+++ b/src/components/Preloader.tsx
@@ -1,4 +1,4 @@
-import ShortLogo from './icons/ShortLogo';
+import { ShortLogo } from './shared/icons';
 
 interface PreloaderProps {
   top: number;

--- a/src/components/ProductDetails.tsx
+++ b/src/components/ProductDetails.tsx
@@ -2,20 +2,20 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Prisma } from '@prisma/client';
-import MobileProductGallery from './product-details/MobileProductGallery';
-import DesktopProductGallery from './product-details/DesktopProductGallery';
-import ProductHeader from './product-details/ProductHeader';
-import AddToCartButton from './product-details/AddToCartButton';
-import SizeSelector from './product-details/SizeSelector';
-import SizeChart from './product-details/SizeChart';
-import ProductAttributes from './product-details/ProductAttributes';
-import BottomSheet from '@/components/ui/BottomSheet';
-import SizeGuideContent from './product-details/SizeGuideContent';
-import DesktopActionButtons from './product-details/DesktopActionButtons';
-import ArrowStep1 from '@/components/illustrations/ArrowStep1';
 import Image from 'next/image';
-import ProductActions from './product-details/ProductActions';
+import { Prisma } from '@prisma/client';
+import ArrowStep1 from '@/components/illustrations/ArrowStep1';
+import DesktopActionButtons from '@/components/site/product/DesktopActionButtons';
+import DesktopProductGallery from '@/components/site/product/DesktopProductGallery';
+import MobileProductGallery from '@/components/site/product/MobileProductGallery';
+import ProductActions from '@/components/site/product/ProductActions';
+import ProductAttributes from '@/components/site/product/ProductAttributes';
+import ProductHeader from '@/components/site/product/ProductHeader';
+import SizeChart from '@/components/site/product/SizeChart';
+import SizeGuideContent from '@/components/site/product/SizeGuideContent';
+import SizeSelector from '@/components/site/product/SizeSelector';
+import AddToCartButton from '@/components/site/product/AddToCartButton';
+import BottomSheet from '@/components/shared/ui/BottomSheet';
 
 // ... (компоненты CountdownTimer и MobileSizeGuideWithAccordion остаются без изменений) ...
 const CountdownTimer = ({

--- a/src/components/admin/AdminHeader.tsx
+++ b/src/components/admin/AdminHeader.tsx
@@ -3,10 +3,9 @@
 import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import ShortLogo from '@/components/icons/ShortLogo';
+import { ChevronIcon, ShortLogo } from '@/components/shared/icons';
 import { useAppStore } from '@/store/useAppStore';
 import { signOut } from 'next-auth/react';
-import ChevronIcon from '../icons/ChevronIcon';
 
 // Определяем структуру ссылок для навигации
 const adminNavLinks = [

--- a/src/components/admin/product-table/ProductSizeRow.tsx
+++ b/src/components/admin/product-table/ProductSizeRow.tsx
@@ -6,10 +6,7 @@ import type { Prisma } from '@prisma/client';
 import toast from 'react-hot-toast';
 import { Copy, Check } from 'lucide-react';
 
-import { PencilIcon } from '@/components/icons/PencilIcon';
-import { CheckIcon } from '@/components/icons/CheckIcon';
-import { XMarkIcon } from '@/components/icons/XMarkIcon';
-import { SpinnerIcon } from '@/components/icons/SpinnerIcon';
+import { CheckIcon, PencilIcon, SpinnerIcon, XMarkIcon } from '@/components/shared/icons';
 
 const useCopyToClipboard = () => {
   const [isCopied, setIsCopied] = useState(false);

--- a/src/components/shared/layout/CatalogHeaderController.tsx
+++ b/src/components/shared/layout/CatalogHeaderController.tsx
@@ -3,12 +3,12 @@
 
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import Header from '@/components/Header';
-import StickyHeader from './StickyHeader';
-import CategoryFilter from '../CategoryFilter';
-import StickyCategoryFilter from './StickyCategoryFilter';
-import CatalogContent from '../CatalogContent';
+import CatalogContent from '@/components/CatalogContent';
+import CategoryFilter from '@/components/CategoryFilter';
 import { useAppStore } from '@/store/useAppStore';
 import { ProductWithInfo } from '@/lib/types';
+import StickyCategoryFilter from './StickyCategoryFilter';
+import StickyHeader from './StickyHeader';
 
 interface Category {
   id: string;

--- a/src/components/shared/layout/ProductPageHeader.tsx
+++ b/src/components/shared/layout/ProductPageHeader.tsx
@@ -3,8 +3,7 @@
 
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import HeartIcon from '@/components/icons/HeartIcon';
-import ShareIcon from '@/components/icons/ShareIcon';
+import { HeartIcon, ShareIcon } from '@/components/shared/icons';
 
 const BackArrowIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg

--- a/src/components/shared/layout/StickyCategoryFilter.tsx
+++ b/src/components/shared/layout/StickyCategoryFilter.tsx
@@ -1,7 +1,7 @@
 // Местоположение: src/components/layout/StickyCategoryFilter.tsx
 'use client';
 
-import CategoryFilter from '../CategoryFilter';
+import CategoryFilter from '@/components/CategoryFilter';
 
 // --- НАЧАЛО ИЗМЕНЕНИЙ: Обновляем "должностную инструкцию" (Props) ---
 // Добавляем все недостающие "пункты", чтобы соответствовать CatalogHeaderController.

--- a/src/components/shared/layout/StickyHeader.tsx
+++ b/src/components/shared/layout/StickyHeader.tsx
@@ -3,11 +3,8 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import Logo from '../icons/Logo';
-import CloseIcon from '../icons/CloseIcon';
-import BurgerIcon from '../icons/BurgerIcon';
-import SearchIcon from '../icons/SearchIcon';
-import DesktopNav from '../header/DesktopNav';
+import { BurgerIcon, CloseIcon, Logo, SearchIcon } from '../icons';
+import DesktopNav from '@/components/site/layout/DesktopNav';
 import { useAppStore } from '@/store/useAppStore';
 
 interface StickyHeaderProps {

--- a/src/components/shared/layout/StickyProductPageHeader.tsx
+++ b/src/components/shared/layout/StickyProductPageHeader.tsx
@@ -3,8 +3,7 @@
 
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import CartIcon from '@/components/icons/CartIcon'; // Импорт пока оставим, вдруг понадобится
-import HeartIcon from '@/components/icons/HeartIcon';
+import { CartIcon, HeartIcon } from '@/components/shared/icons';
 
 const BackArrowIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg

--- a/src/components/shared/modals/VerificationModal.tsx
+++ b/src/components/shared/modals/VerificationModal.tsx
@@ -5,8 +5,8 @@ import { useRouter } from 'next/navigation'; // <-- ШАГ 1: Импортиру
 import { signIn } from 'next-auth/react';
 // useAppStore больше не нужен для обновления, но может понадобиться для чего-то еще, пока оставим
 import { useAppStore } from '@/store/useAppStore';
+import { CloseIcon } from '../icons';
 import CodeInput from './CodeInput';
-import CloseIcon from '../icons/CloseIcon';
 
 interface VerificationModalProps {
   isOpen: boolean;

--- a/src/components/shared/ui/BottomSheet.tsx
+++ b/src/components/shared/ui/BottomSheet.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import CloseIcon from '@/components/icons/CloseIcon';
+import { CloseIcon } from '@/components/shared/icons';
 
 interface BottomSheetProps {
   isOpen: boolean;

--- a/src/components/site/auth/ForgotPasswordForm.tsx
+++ b/src/components/site/auth/ForgotPasswordForm.tsx
@@ -4,7 +4,7 @@
 import { useState, FormEvent, useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
 import toast from 'react-hot-toast';
-import ClearIcon from '@/components/icons/ClearIcon'; // Импортируем иконку
+import { ClearIcon } from '@/components/shared/icons'; // Импортируем иконку
 
 export function ForgotPasswordForm() {
   const searchParams = useSearchParams();

--- a/src/components/site/auth/ResetPasswordForm.tsx
+++ b/src/components/site/auth/ResetPasswordForm.tsx
@@ -4,7 +4,7 @@
 import { useState, FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import toast from 'react-hot-toast';
-import ClearIcon from '@/components/icons/ClearIcon';
+import { ClearIcon } from '@/components/shared/icons';
 
 export function ResetPasswordForm({ token }: { token: string }) {
   const router = useRouter();

--- a/src/components/site/auth/VerificationModal.tsx
+++ b/src/components/site/auth/VerificationModal.tsx
@@ -2,8 +2,8 @@
 
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import { CloseIcon } from '@/components/shared/icons';
 import CodeInput from './CodeInput';
-import CloseIcon from '../icons/CloseIcon';
 
 interface VerificationModalProps {
   isOpen: boolean;

--- a/src/components/site/layout/DesktopNav.tsx
+++ b/src/components/site/layout/DesktopNav.tsx
@@ -1,11 +1,9 @@
 // Местоположение: src/components/header/DesktopNav.tsx
 import Link from 'next/link';
-import SearchIcon from '../icons/SearchIcon';
-import CartIcon from '../icons/CartIcon';
 import { NAV_LINKS } from '@/config/navigation';
 // --- НАЧАЛО ИЗМЕНЕНИЙ ---
 import { Session } from 'next-auth'; // Импортируем тип Session
-import UserIcon from '../icons/UserIcon';
+import { CartIcon, SearchIcon, UserIcon } from '@/components/shared/icons';
 // --- КОНЕЦ ИЗМЕНЕНИЙ ---
 
 // --- НАЧАЛО ИЗМЕНЕНИЙ ---

--- a/src/components/site/product/AddToCartButton.tsx
+++ b/src/components/site/product/AddToCartButton.tsx
@@ -1,7 +1,7 @@
 // Местоположение: src/components/product-details/AddToCartButton.tsx
 'use client';
 
-import Button from '@/components/ui/Button';
+import { Button } from '@/components/shared/ui';
 
 // --- Иконки для счетчика ---
 const MinusIcon = (props: React.SVGProps<SVGSVGElement>) => (

--- a/src/components/site/product/DesktopActionButtons.tsx
+++ b/src/components/site/product/DesktopActionButtons.tsx
@@ -4,7 +4,7 @@
 // Убираем ненужные хуки для отслеживания скролла
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import HeartIcon from '../icons/HeartIcon';
+import { HeartIcon } from '@/components/shared/icons';
 
 const BackArrowIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg

--- a/src/components/site/product/DesktopSizeAndCartButton.tsx
+++ b/src/components/site/product/DesktopSizeAndCartButton.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import { useState, useRef, useEffect } from 'react';
-import Button from '@/components/ui/Button';
+import { Button } from '@/components/shared/ui';
 
 // --- Иконки для счетчика ---
 const MinusIcon = (props: React.SVGProps<SVGSVGElement>) => (

--- a/src/components/site/product/ProductAttributes.tsx
+++ b/src/components/site/product/ProductAttributes.tsx
@@ -3,9 +3,8 @@
 
 import { useState, useRef, useEffect } from 'react';
 // --- НАЧАЛО ИЗМЕНЕНИЙ: Исправляем импорт CopyIcon ---
-import CopyIcon from '@/components/icons/CopyIcon'; // Импорт по умолчанию
+import { CheckIcon, CopyIcon } from '@/components/shared/icons';
 import { useAppStore } from '@/store/useAppStore';
-import { CheckIcon } from '@/components/icons/CheckIcon'; // Именованный импорт
 // --- КОНЕЦ ИЗМЕНЕНИЙ ---
 
 const ChevronIcon = ({ isOpen }: { isOpen: boolean }) => (

--- a/src/components/site/product/ProductHeader.tsx
+++ b/src/components/site/product/ProductHeader.tsx
@@ -1,8 +1,8 @@
 // Местоположение: src/components/product-details/ProductHeader.tsx
 'use client';
 
+import { ShortLogo } from '@/components/shared/icons';
 import { formatPrice } from '@/utils/formatPrice';
-import ShortLogo from '../icons/ShortLogo';
 
 interface ProductHeaderProps {
   name: string;

--- a/src/components/site/product/SizeSelector.tsx
+++ b/src/components/site/product/SizeSelector.tsx
@@ -1,8 +1,8 @@
 // Местоположение: src/components/product-details/SizeSelector.tsx
 'use client';
 
+import { HeartIcon } from '@/components/shared/icons';
 import LowStockBadge from './LowStockBadge';
-import HeartIcon from '../icons/HeartIcon';
 
 interface InventoryItem {
   size: { id: string; value: string };

--- a/src/components/site/profile/ProfileHeader.tsx
+++ b/src/components/site/profile/ProfileHeader.tsx
@@ -5,8 +5,7 @@ import type { User } from '@prisma/client'; // <-- ИЗМЕНЕНО: Возвр�
 import Image from 'next/image';
 
 import AvatarPlaceholder from '@/components/AvatarPlaceholder';
-import ShortLogo from '@/components/icons/ShortLogo';
-import SettingsIcon from '../icons/SettingsIcon';
+import { SettingsIcon, ShortLogo } from '@/components/shared/icons';
 // --- УДАЛЕНО: Убираем импорт серверной утилиты ---
 // import { decrypt } from '@/lib/encryption';
 

--- a/src/components/site/profile/ProfileInfoBlock.tsx
+++ b/src/components/site/profile/ProfileInfoBlock.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import SettingsIcon from '../icons/SettingsIcon';
+import { SettingsIcon } from '@/components/shared/icons';
 
 interface ProfileInfoBlockProps {
   title: string;

--- a/src/lib/telegram.ts
+++ b/src/lib/telegram.ts
@@ -2,49 +2,42 @@ import { Telegraf, Context, Markup } from 'telegraf';
 import prisma from '@/lib/prisma';
 import nodemailer from 'nodemailer';
 
-// --- Валидация переменных окружения ---
-const clientBotToken = process.env.TELEGRAM_BOT_TOKEN;
-if (!clientBotToken) {
-  throw new Error('Критическая ошибка: TELEGRAM_BOT_TOKEN не определен.');
+const AGENT_KEYBOARD = Markup.keyboard([
+  ['📝 Открытые тикеты'],
+  ['🆘 Помощь'],
+]).resize();
+
+function getRequiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Критическая ошибка: ${name} не определен.`);
+  }
+  return value;
 }
 
-const supportBotToken = process.env.TELEGRAM_SUPPORT_BOT_TOKEN;
-if (!supportBotToken) {
-  throw new Error(
-    'Критическая ошибка: TELEGRAM_SUPPORT_BOT_TOKEN не определен.',
-  );
-}
+const handleBotError = (error: unknown, botName: string) => {
+  console.error(`Ошибка в [${botName}]:`, error);
+};
 
-const baseUrl = process.env.NEXTAUTH_URL;
-if (!baseUrl) {
-  throw new Error('Критическая ошибка: NEXTAUTH_URL не определен.');
-}
+let clientBotInstance: Telegraf<Context> | null = null;
+let supportBotInstance: Telegraf<Context> | null = null;
 
-// --- Инициализация Инстансов Ботов ---
-export const clientBot = new Telegraf(clientBotToken);
-export const supportBot = new Telegraf(supportBotToken);
+function setupClientBot(bot: Telegraf<Context>, baseUrl: string) {
+  bot.command('start', async (ctx) => {
+    const loginToken = ctx.payload;
 
-// ==================================================================
-// --- ЛОГИКА КЛИЕНТСКОГО БОТА (ClientBot) ---
-// ==================================================================
+    if (loginToken) {
+      console.log(`[Client Bot] Найден login token: ${loginToken}`);
+      await ctx.reply(`Обрабатываем ваш токен для входа...`);
+      return;
+    }
 
-clientBot.command('start', async (ctx) => {
-  // Telegraf элегантно предоставляет текст после команды в ctx.payload
-  const loginToken = ctx.payload;
-
-  if (loginToken) {
-    console.log(`[Client Bot] Найден login token: ${loginToken}`);
-    // Здесь будет логика для автоматического входа пользователя по токену.
-    // Пока что просто отвечаем.
-    await ctx.reply(`Обрабатываем ваш токен для входа...`);
-  } else {
     console.log(
       '[Client Bot] Команда /start без токена, отправляем приветствие.',
     );
     const welcomeText =
       'Добро пожаловать в Kyanchir Store!\n\nЧтобы войти на сайт, нажмите кнопку ниже.';
 
-    // Создаем клавиатуру с помощью хелперов Telegraf
     const keyboard = Markup.keyboard([
       [Markup.button.webApp('Войти на сайт', `${baseUrl}/login`)],
       [Markup.button.contactRequest('📱 Поделиться номером')],
@@ -53,212 +46,221 @@ clientBot.command('start', async (ctx) => {
       .oneTime();
 
     await ctx.reply(welcomeText, keyboard);
-  }
-});
-
-// ==================================================================
-// --- ЛОГИКА БОТА ПОДДЕРЖКИ (SupportBot) ---
-// ==================================================================
-
-const AGENT_KEYBOARD = Markup.keyboard([
-  ['📝 Открытые тикеты'],
-  ['🆘 Помощь'],
-]).resize();
-
-const verifyAgent = async (ctx: Context, next: () => Promise<void>) => {
-  const telegramId = ctx.from?.id;
-  if (!telegramId) return;
-
-  const agent = await prisma.supportAgent.findFirst({
-    where: { telegramId: String(telegramId) },
   });
 
-  if (!agent) {
+  bot.catch((err) => handleBotError(err, 'ClientBot'));
+}
+
+function setupSupportBot(bot: Telegraf<Context>) {
+  const verifyAgent = async (ctx: Context, next: () => Promise<void>) => {
+    const telegramId = ctx.from?.id;
+    if (!telegramId) return;
+
+    const agent = await prisma.supportAgent.findFirst({
+      where: { telegramId: String(telegramId) },
+    });
+
+    if (!agent) {
+      await ctx.reply(
+        '❌ Доступ запрещен. Вы не являетесь верифицированным агентом поддержки.',
+      );
+      return;
+    }
+    (ctx as any).agent = agent;
+    await next();
+  };
+
+  bot.command('start', verifyAgent, async (ctx) => {
     await ctx.reply(
-      '❌ Доступ запрещен. Вы не являетесь верифицированным агентом поддержки.',
-    );
-    return;
-  }
-  (ctx as any).agent = agent;
-  await next();
-};
-
-supportBot.command('start', verifyAgent, async (ctx) => {
-  await ctx.reply(
-    `👋 Добро пожаловать, ${(ctx as any).agent.name}! Готовы к работе.`,
-    AGENT_KEYBOARD,
-  );
-});
-
-const handleTicketsRequest = async (ctx: Context) => {
-  await ctx.reply('⏳ Загружаю список открытых тикетов...');
-};
-supportBot.command('tickets', verifyAgent, handleTicketsRequest);
-supportBot.hears('📝 Открытые тикеты', verifyAgent, handleTicketsRequest);
-
-supportBot.on('message', verifyAgent, async (ctx) => {
-  if (!('text' in ctx.message) || !ctx.message.reply_to_message) {
-    return ctx.reply(
-      'Неизвестная команда. Используйте клавиатуру или команды /start, /tickets.',
+      `👋 Добро пожаловать, ${(ctx as any).agent.name}! Готовы к работе.`,
       AGENT_KEYBOARD,
     );
-  }
-
-  const text = ctx.message.text;
-  const originalMessage = ctx.message.reply_to_message;
-
-  if (!('text' in originalMessage) || !originalMessage.text) return;
-
-  const idMatch = originalMessage.text.match(/ID тикета: ([a-zA-Z0-9-]+)/);
-  if (!idMatch || !idMatch[1]) {
-    return ctx.reply(
-      '⚠️ Не удалось найти ID тикета. Отвечайте только на уведомления о тикетах.',
-    );
-  }
-  const ticketId = idMatch[1];
-  const agent = (ctx as any).agent;
-
-  await prisma.temporaryReply.create({
-    data: {
-      agentMessageId: BigInt(ctx.message.message_id),
-      replyText: text,
-      ticketId: ticketId,
-      agentId: agent.id,
-    },
   });
 
-  const availableEmails = await prisma.supportRoute.findMany({
-    select: { kyanchirEmail: true },
-  });
+  const handleTicketsRequest = async (ctx: Context) => {
+    await ctx.reply('⏳ Загружаю список открытых тикетов...');
+  };
+  bot.command('tickets', verifyAgent, handleTicketsRequest);
+  bot.hears('📝 Открытые тикеты', verifyAgent, handleTicketsRequest);
 
-  if (availableEmails.length === 0) {
-    return ctx.reply('❌ В базе не найдено ни одного email для отправки.');
-  }
+  bot.on('message', verifyAgent, async (ctx) => {
+    if (!('text' in ctx.message) || !ctx.message.reply_to_message) {
+      return ctx.reply(
+        'Неизвестная команда. Используйте клавиатуру или команды /start, /tickets.',
+        AGENT_KEYBOARD,
+      );
+    }
 
-  const emailButtons = availableEmails.map((route) =>
-    Markup.button.callback(
-      route.kyanchirEmail,
-      `reply_${route.kyanchirEmail}_${ticketId}_${ctx.message.message_id}`,
-    ),
-  );
+    const text = ctx.message.text;
+    const originalMessage = ctx.message.reply_to_message;
 
-  await ctx.reply(
-    '👇 С какой почты отправить этот ответ?',
-    Markup.inlineKeyboard(emailButtons),
-  );
-});
+    if (!('text' in originalMessage) || !originalMessage.text) return;
 
-supportBot.action(/ticket_(ack|close)_(.+)/, verifyAgent, async (ctx) => {
-  const agent = (ctx as any).agent;
-  const action = ctx.match[1];
-  const ticketId = ctx.match[2];
-  const originalMessage = ctx.callbackQuery.message;
+    const idMatch = originalMessage.text.match(/ID тикета: ([a-zA-Z0-9-]+)/);
+    if (!idMatch || !idMatch[1]) {
+      return ctx.reply(
+        '⚠️ Не удалось найти ID тикета. Отвечайте только на уведомления о тикетах.',
+      );
+    }
+    const ticketId = idMatch[1];
+    const agent = (ctx as any).agent;
 
-  if (!originalMessage || !('text' in originalMessage)) {
-    await ctx.answerCbQuery(
-      'Не удалось обработать: исходное сообщение не является текстом.',
-      { show_alert: true },
-    );
-    return;
-  }
-
-  let newStatusName: string | undefined;
-  let responseText = '';
-
-  if (action === 'ack') {
-    newStatusName = 'PENDING';
-    responseText = `⏳ Тикет взят в работу агентом ${agent.name}`;
-  } else if (action === 'close') {
-    newStatusName = 'RESOLVED';
-    responseText = `✅ Тикет закрыт агентом ${agent.name}`;
-  }
-
-  if (newStatusName) {
-    const statusToSet = await prisma.ticketStatus.findUnique({
-      where: { name: newStatusName },
+    await prisma.temporaryReply.create({
+      data: {
+        agentMessageId: BigInt(ctx.message.message_id),
+        replyText: text,
+        ticketId: ticketId,
+        agentId: agent.id,
+      },
     });
-    if (!statusToSet) throw new Error(`Статус ${newStatusName} не найден в БД`);
 
-    await prisma.supportTicket.update({
+    const availableEmails = await prisma.supportRoute.findMany({
+      select: { kyanchirEmail: true },
+    });
+
+    if (availableEmails.length === 0) {
+      return ctx.reply('❌ В базе не найдено ни одного email для отправки.');
+    }
+
+    const emailButtons = availableEmails.map((route) =>
+      Markup.button.callback(
+        route.kyanchirEmail,
+        `reply_${route.kyanchirEmail}_${ticketId}_${ctx.message.message_id}`,
+      ),
+    );
+
+    await ctx.reply(
+      '👇 С какой почты отправить этот ответ?',
+      Markup.inlineKeyboard(emailButtons),
+    );
+  });
+
+  bot.action(/ticket_(ack|close)_(.+)/, verifyAgent, async (ctx) => {
+    const agent = (ctx as any).agent;
+    const action = ctx.match[1];
+    const ticketId = ctx.match[2];
+    const originalMessage = ctx.callbackQuery.message;
+
+    if (!originalMessage || !('text' in originalMessage)) {
+      await ctx.answerCbQuery(
+        'Не удалось обработать: исходное сообщение не является текстом.',
+        { show_alert: true },
+      );
+      return;
+    }
+
+    let newStatusName: string | undefined;
+    let responseText = '';
+
+    if (action === 'ack') {
+      newStatusName = 'PENDING';
+      responseText = `⏳ Тикет взят в работу агентом ${agent.name}`;
+    } else if (action === 'close') {
+      newStatusName = 'RESOLVED';
+      responseText = `✅ Тикет закрыт агентом ${agent.name}`;
+    }
+
+    if (newStatusName) {
+      const statusToSet = await prisma.ticketStatus.findUnique({
+        where: { name: newStatusName },
+      });
+      if (!statusToSet) throw new Error(`Статус ${newStatusName} не найден в БД`);
+
+      await prisma.supportTicket.update({
+        where: { id: ticketId },
+        data: { statusId: statusToSet.id },
+      });
+
+      await ctx.editMessageText(
+        `${originalMessage.text}\n\n---\n<b>${responseText}</b>`,
+        { parse_mode: 'HTML' },
+      );
+      await ctx.answerCbQuery('Статус тикета обновлен!');
+    }
+  });
+
+  bot.action(/reply_(.+)_(.+)_(.+)/, verifyAgent, async (ctx) => {
+    const agent = (ctx as any).agent;
+    const fromEmail = ctx.match[1];
+    const ticketId = ctx.match[2];
+    const agentMessageId = BigInt(ctx.match[3]);
+
+    const tempReply = await prisma.temporaryReply.findUnique({
+      where: { agentMessageId },
+    });
+
+    if (!tempReply) {
+      await ctx.editMessageText(
+        '❌ Время сессии истекло, текст ответа утерян. Пожалуйста, попробуйте ответить на тикет заново.',
+      );
+      return ctx.answerCbQuery('Ошибка', { show_alert: true });
+    }
+
+    const ticket = await prisma.supportTicket.findUnique({
       where: { id: ticketId },
-      data: { statusId: statusToSet.id },
     });
+    if (!ticket) return;
+
+    const transporter = nodemailer.createTransport({
+      host: process.env.EMAIL_SERVER_HOST,
+      port: parseInt(process.env.EMAIL_SERVER_PORT!),
+      auth: {
+        user: process.env.EMAIL_SERVER_USER,
+        pass: process.env.EMAIL_SERVER_PASSWORD,
+      },
+    });
+
+    await transporter.sendMail({
+      from: `"${agent.name} (Kyanchir Support)" <${fromEmail}>`,
+      to: ticket.clientEmail,
+      subject: `Re: ${ticket.subject}`,
+      text: tempReply.replyText,
+      html: `<p>${tempReply.replyText.replace(/\n/g, '<br>')}</p>`,
+    });
+
+    const agentSenderType = await prisma.senderType.findUnique({
+      where: { name: 'AGENT' },
+    });
+    if (!agentSenderType) throw new Error('SenderType AGENT не найден');
+
+    await prisma.supportMessage.create({
+      data: {
+        ticketId: ticket.id,
+        content: tempReply.replyText,
+        senderTypeId: agentSenderType.id,
+        agentId: agent.id,
+      },
+    });
+
+    await prisma.temporaryReply.delete({ where: { agentMessageId } });
 
     await ctx.editMessageText(
-      `${originalMessage.text}\n\n---\n<b>${responseText}</b>`,
+      `✅ Ответ успешно отправлен клиенту ${ticket.clientEmail} с почты <b>${fromEmail}</b>.`,
       { parse_mode: 'HTML' },
     );
-    await ctx.answerCbQuery('Статус тикета обновлен!');
+    await ctx.answerCbQuery('Отправлено!');
+  });
+
+  bot.catch((err) => handleBotError(err, 'SupportBot'));
+}
+
+export function getClientBot(): Telegraf<Context> {
+  if (!clientBotInstance) {
+    const token = getRequiredEnv('TELEGRAM_BOT_TOKEN');
+    const baseUrl = getRequiredEnv('NEXTAUTH_URL');
+    clientBotInstance = new Telegraf(token);
+    setupClientBot(clientBotInstance, baseUrl);
+    console.log('🤖 ClientBot инициализирован.');
   }
-});
+  return clientBotInstance;
+}
 
-supportBot.action(/reply_(.+)_(.+)_(.+)/, verifyAgent, async (ctx) => {
-  const agent = (ctx as any).agent;
-  const fromEmail = ctx.match[1];
-  const ticketId = ctx.match[2];
-  const agentMessageId = BigInt(ctx.match[3]);
-
-  const tempReply = await prisma.temporaryReply.findUnique({
-    where: { agentMessageId },
-  });
-
-  if (!tempReply) {
-    await ctx.editMessageText(
-      '❌ Время сессии истекло, текст ответа утерян. Пожалуйста, попробуйте ответить на тикет заново.',
-    );
-    return ctx.answerCbQuery('Ошибка', { show_alert: true });
+export function getSupportBot(): Telegraf<Context> {
+  if (!supportBotInstance) {
+    const token = getRequiredEnv('TELEGRAM_SUPPORT_BOT_TOKEN');
+    supportBotInstance = new Telegraf(token);
+    setupSupportBot(supportBotInstance);
+    console.log('🤖 SupportBot инициализирован.');
   }
-
-  const ticket = await prisma.supportTicket.findUnique({
-    where: { id: ticketId },
-  });
-  if (!ticket) return;
-
-  const transporter = nodemailer.createTransport({
-    host: process.env.EMAIL_SERVER_HOST,
-    port: parseInt(process.env.EMAIL_SERVER_PORT!),
-    auth: {
-      user: process.env.EMAIL_SERVER_USER,
-      pass: process.env.EMAIL_SERVER_PASSWORD,
-    },
-  });
-
-  await transporter.sendMail({
-    from: `"${agent.name} (Kyanchir Support)" <${fromEmail}>`,
-    to: ticket.clientEmail,
-    subject: `Re: ${ticket.subject}`,
-    text: tempReply.replyText,
-    html: `<p>${tempReply.replyText.replace(/\n/g, '<br>')}</p>`,
-  });
-
-  const agentSenderType = await prisma.senderType.findUnique({
-    where: { name: 'AGENT' },
-  });
-  if (!agentSenderType) throw new Error('SenderType AGENT не найден');
-
-  await prisma.supportMessage.create({
-    data: {
-      ticketId: ticket.id,
-      content: tempReply.replyText,
-      senderTypeId: agentSenderType.id,
-      agentId: agent.id,
-    },
-  });
-
-  await prisma.temporaryReply.delete({ where: { agentMessageId } });
-
-  await ctx.editMessageText(
-    `✅ Ответ успешно отправлен клиенту ${ticket.clientEmail} с почты <b>${fromEmail}</b>.`,
-    { parse_mode: 'HTML' },
-  );
-  await ctx.answerCbQuery('Отправлено!');
-});
-
-// --- Глобальный Обработчик Ошибок ---
-const handleBotError = (error: unknown, botName: string) => {
-  console.error(`Ошибка в [${botName}]:`, error);
-};
-clientBot.catch((err, ctx) => handleBotError(err, 'ClientBot'));
-supportBot.catch((err, ctx) => handleBotError(err, 'SupportBot'));
-
-console.log('🤖 Telegraf-боты и их логика инициализированы...');
+  return supportBotInstance;
+}


### PR DESCRIPTION
## Summary
- defer encryption key and salt validation until runtime so server modules no longer crash during import
- lazily initialize Telegram bots and update API routes to request bot instances only when handling a webhook or support ticket
- skip login token creation during the production build phase to keep the Next.js build from touching the database

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e54a8d2de4833180c273f216ab712d