### PR TITLE
Add migration for product slug column

### DIFF
--- a/prisma/migrations/20251007213000_add_product_slug/migration.sql
+++ b/prisma/migrations/20251007213000_add_product_slug/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "public"."Product" ADD COLUMN "slug" TEXT;
+
+CREATE UNIQUE INDEX "Product_slug_key" ON "public"."Product"("slug");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,6 +15,7 @@ model Product {
   id               String            @id @default(cuid())
   article          String?           @unique
   name             String            @unique
+  slug             String?           @unique
   alternativeNames AlternativeName[]
   description      String?           @db.Text
   variants         ProductVariant[]

--- a/src/app/(site)/cart/page.tsx
+++ b/src/app/(site)/cart/page.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/store/useCartStore';
 import { formatPrice } from '@/utils/formatPrice';
 import { TrashIcon } from '@/components/shared/icons';
+import { createSlug } from '@/utils/createSlug';
 
 const formatItemsLabel = (count: number) => {
   if (count === 1) return 'товар';
@@ -74,13 +75,15 @@ export default function CartPage() {
             const isIncreaseDisabled = item.quantity >= item.maxQuantity;
             const stockLeft = item.maxQuantity - item.quantity;
 
+            const productLink = item.productSlug ?? createSlug(item.name);
+
             return (
               <article
                 key={item.productSizeId}
                 className="flex flex-col gap-4 rounded-lg border border-gray-200 p-4 shadow-sm sm:flex-row"
               >
                 <Link
-                  href={`/product/${item.productId}`}
+                  href={`/product/${productLink}`}
                   className="flex h-32 w-full flex-shrink-0 items-center justify-center overflow-hidden rounded-md bg-gray-100 sm:h-32 sm:w-32"
                 >
                   {item.imageUrl ? (
@@ -99,7 +102,7 @@ export default function CartPage() {
                 <div className="flex flex-1 flex-col justify-between gap-3">
                   <div className="space-y-1">
                     <Link
-                      href={`/product/${item.productId}`}
+                      href={`/product/${productLink}`}
                       className="text-base font-semibold text-gray-900 transition hover:text-gray-700"
                     >
                       {item.name}

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -10,6 +10,7 @@ import ImagePlaceholder from './ImagePlaceholder';
 import { HeartIcon } from '@/components/shared/icons'; // ОБНОВЛЕННЫЙ ИМПОРТ
 import { ProductWithInfo } from '@/lib/types';
 import { SkeletonLoader } from '@/components/shared/ui';
+import { createSlug } from '@/utils/createSlug';
 
 interface ProductCardProps {
   product: ProductWithInfo;
@@ -74,9 +75,11 @@ export default function ProductCard({ product }: ProductCardProps) {
     });
   };
 
+  const slug = product.slug ?? createSlug(product.name);
+
   return (
     <Link
-      href={`/product/${product.id}`}
+      href={`/product/${slug}`}
       className="group mx-auto flex w-full flex-col text-text-primary md:max-w-[330px]"
     >
       {/* ИЗМЕНЕНИЕ 3: Сетка теперь состоит только из 2-х колонок, без рядов */}

--- a/src/components/ProductDetails.tsx
+++ b/src/components/ProductDetails.tsx
@@ -19,6 +19,7 @@ import BottomSheet from '@/components/shared/ui/BottomSheet';
 import { CheckIcon, XMarkIcon } from '@/components/shared/icons';
 import { useCartStore } from '@/store/useCartStore';
 import { useAppStore } from '@/store/useAppStore';
+import { createSlug } from '@/utils/createSlug';
 
 // ... (компоненты CountdownTimer и MobileSizeGuideWithAccordion остаются без изменений) ...
 const CountdownTimer = ({
@@ -348,6 +349,7 @@ export default function ProductDetails({ product }: ProductDetailsProps) {
     addItemToCart(
       {
         productId: product.id,
+        productSlug: product.slug ?? createSlug(product.name),
         variantId: selectedVariant.id,
         productSizeId: sizeInfo.id,
         name: product.name,

--- a/src/utils/createSlug.ts
+++ b/src/utils/createSlug.ts
@@ -1,0 +1,114 @@
+const CYRILLIC_TO_LATIN: Record<string, string> = {
+  'а': 'a',
+  'б': 'b',
+  'в': 'v',
+  'г': 'g',
+  'д': 'd',
+  'е': 'e',
+  'ё': 'e',
+  'ж': 'zh',
+  'з': 'z',
+  'и': 'i',
+  'й': 'y',
+  'к': 'k',
+  'л': 'l',
+  'м': 'm',
+  'н': 'n',
+  'о': 'o',
+  'п': 'p',
+  'р': 'r',
+  'с': 's',
+  'т': 't',
+  'у': 'u',
+  'ф': 'f',
+  'х': 'h',
+  'ц': 'ts',
+  'ч': 'ch',
+  'ш': 'sh',
+  'щ': 'shch',
+  'ъ': '',
+  'ы': 'y',
+  'ь': '',
+  'э': 'e',
+  'ю': 'yu',
+  'я': 'ya',
+};
+
+const EXTRA_SYMBOLS: Record<string, string> = {
+  'æ': 'ae',
+  'œ': 'oe',
+  'ø': 'o',
+  'å': 'a',
+  'ä': 'a',
+  'ö': 'o',
+  'ü': 'u',
+  'ß': 'ss',
+};
+
+const FALLBACK_SLUG = 'product';
+
+const replaceCyrillic = (value: string) =>
+  value
+    .split('')
+    .map((char) => {
+      const lowerChar = char.toLowerCase();
+      if (CYRILLIC_TO_LATIN[lowerChar]) {
+        const replacement = CYRILLIC_TO_LATIN[lowerChar];
+        return char === lowerChar
+          ? replacement
+          : replacement.charAt(0).toUpperCase() + replacement.slice(1);
+      }
+
+      if (EXTRA_SYMBOLS[lowerChar]) {
+        const replacement = EXTRA_SYMBOLS[lowerChar];
+        return char === lowerChar
+          ? replacement
+          : replacement.charAt(0).toUpperCase() + replacement.slice(1);
+      }
+
+      return char;
+    })
+    .join('');
+
+const sanitize = (value: string) =>
+  value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, ' ')
+    .replace(/[\s_-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+export const createSlug = (value: string) => {
+  if (!value || typeof value !== 'string') {
+    return FALLBACK_SLUG;
+  }
+
+  const transliterated = replaceCyrillic(value);
+  const slug = sanitize(transliterated);
+
+  if (slug.length === 0) {
+    const alphanumeric = value.replace(/[^a-z0-9]/gi, '');
+    return alphanumeric.length > 0
+      ? alphanumeric.toLowerCase()
+      : `${FALLBACK_SLUG}-${Date.now()}`;
+  }
+
+  return slug;
+};
+
+export const ensureUniqueSlug = async (
+  slug: string,
+  isTaken: (candidate: string) => Promise<boolean>,
+) => {
+  let candidate = slug;
+  let suffix = 1;
+
+  while (await isTaken(candidate)) {
+    candidate = `${slug}-${suffix}`;
+    suffix += 1;
+  }
+
+  return candidate;
+};
+


### PR DESCRIPTION
## Summary
- add a Prisma migration that creates the `slug` column on `Product`
- create a unique index so slug-based routing works once the migration is applied

## Testing
- `npm run lint` *(fails: Next.js prompts to configure ESLint interactively)*
- `npm run test` *(fails: missing npm script)*

------
https://chatgpt.com/codex/tasks/task_e_68e58112b7648331a24e3acaf65b8223