### PR TITLE
Smooth hybrid header interactions

### DIFF
--- a/src/components/AppCore.tsx
+++ b/src/components/AppCore.tsx
@@ -20,6 +20,8 @@ export default function AppCore({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const isHomePage = pathname === '/';
   const isProfilePage = pathname === '/profile';
+  const isProductPage =
+    pathname.startsWith('/p/') || pathname.startsWith('/product/');
 
   const isAuthPage =
     pathname.startsWith('/login') ||
@@ -92,22 +94,24 @@ export default function AppCore({ children }: { children: React.ReactNode }) {
     return <main>{children}</main>;
   }
 
+  const mainStyle =
+    isHomePage || isProfilePage || isProductPage
+      ? { paddingTop: 'var(--header-height, 70px)' }
+      : {};
+
+  const contentClassName = isProductPage
+    ? 'mx-auto w-full px-0 pb-16 pt-4 sm:px-4 lg:px-10 xl:px-16'
+    : 'sm-px-6 container mx-auto px-4 py-12 lg:px-8 xl:px-12';
+
   return (
     <FooterProvider>
       <NetworkStatusManager />
       <NotificationManager />
       <ConditionalHeader />
       <SearchOverlay />
-      <main
-        className="flex-grow"
-        style={
-          isHomePage || isProfilePage
-            ? { paddingTop: 'var(--header-height, 70px)' }
-            : {}
-        }
-      >
+      <main className="flex-grow" style={mainStyle}>
         {isHomePage && <DynamicHeroSection />}
-        <div className="sm-px-6 container mx-auto px-4 py-12 lg:px-8 xl:px-12">
+        <div className={contentClassName}>
           {children}
         </div>
       </main>

--- a/src/components/HybridHeader.tsx
+++ b/src/components/HybridHeader.tsx
@@ -22,7 +22,10 @@ export default function HybridHeader() {
 
   // --- НАЧАЛО ИЗМЕНЕНИЙ: Передаем состояние оверлея в хук ---
   const isOverlayOpen = isSearchActive || isFloatingMenuOpen;
-  const { translateY, opacity } = useHybridHeader(headerRef, isOverlayOpen);
+  const { translateY, opacity, isSnapping } = useHybridHeader(
+    headerRef,
+    isOverlayOpen,
+  );
   // --- КОНЕЦ ИЗМЕНЕНИЙ ---
 
   useEffect(() => {
@@ -50,7 +53,9 @@ export default function HybridHeader() {
       className="fixed left-0 right-0 top-0 z-[100] will-change-transform"
       style={{
         transform: `translateY(${translateY}px)`,
-        transition: 'transform 220ms cubic-bezier(.2,.8,.2,1)',
+        transition: isSnapping
+          ? 'transform 220ms cubic-bezier(.2,.8,.2,1)'
+          : 'transform 0s linear',
       }}
     >
       <Header

--- a/src/components/ProductDetails.tsx
+++ b/src/components/ProductDetails.tsx
@@ -404,9 +404,9 @@ export default function ProductDetails({ product }: ProductDetailsProps) {
 
   return (
     <>
-      <div className="mx-auto max-w-7xl px-[15px] lg:px-8 lg:pt-[95px]">
+      <div className="mx-auto w-full max-w-7xl px-4 lg:px-10">
         <div className="pb-32 lg:hidden">
-          <div className="mx-[-15px]">
+          <div className="-mx-4">
             <MobileProductGallery
               images={selectedVariant.images}
               productName={product.name}

--- a/src/components/shared/layout/ProductPageHeader.tsx
+++ b/src/components/shared/layout/ProductPageHeader.tsx
@@ -1,8 +1,11 @@
 // Местоположение: src/components/layout/ProductPageHeader.tsx
 'use client';
 
+import { useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
+import { useHybridHeader } from '@/components/hooks/useHybridHeader';
+import { useAppStore } from '@/store/useAppStore';
 import { HeartIcon, ShareIcon } from '@/components/shared/icons';
 
 const BackArrowIcon = (props: React.SVGProps<SVGSVGElement>) => (
@@ -42,6 +45,33 @@ const SearchIcon = (props: React.SVGProps<SVGSVGElement>) => (
 
 export default function ProductPageHeader() {
   const router = useRouter();
+  const headerRef = useRef<HTMLElement | null>(null);
+  const { isSearchActive, isFloatingMenuOpen } = useAppStore((state) => ({
+    isSearchActive: state.isSearchActive,
+    isFloatingMenuOpen: state.isFloatingMenuOpen,
+  }));
+  const { translateY, opacity, isSnapping } = useHybridHeader(
+    headerRef,
+    isSearchActive || isFloatingMenuOpen,
+  );
+
+  useEffect(() => {
+    const updateHeaderHeight = () => {
+      if (!headerRef.current) return;
+      document.documentElement.style.setProperty(
+        '--header-height',
+        `${headerRef.current.offsetHeight}px`,
+      );
+    };
+
+    updateHeaderHeight();
+    window.addEventListener('resize', updateHeaderHeight);
+
+    return () => {
+      window.removeEventListener('resize', updateHeaderHeight);
+      document.documentElement.style.removeProperty('--header-height');
+    };
+  }, []);
 
   const handleBackClick = () => {
     if (
@@ -74,8 +104,20 @@ export default function ProductPageHeader() {
   // --- КОНЕЦ ИЗМЕНЕНИЙ ---
 
   return (
-    <header className="relative z-10 bg-white lg:hidden">
-      <div className="flex h-16 w-full items-center gap-x-3 px-4">
+    <header
+      ref={headerRef}
+      className="fixed inset-x-0 top-0 z-[100] bg-white lg:hidden"
+      style={{
+        transform: `translateY(${translateY}px)`,
+        transition: isSnapping
+          ? 'transform 220ms cubic-bezier(.2,.8,.2,1)'
+          : 'transform 0s linear',
+      }}
+    >
+      <div
+        className="flex h-16 w-full items-center gap-x-3 px-4"
+        style={{ opacity }}
+      >
         <button
           onClick={handleBackClick}
           aria-label="Вернуться назад"


### PR DESCRIPTION
## Summary
- treat product detail routes as full-width pages in `AppCore`, trimming the default container padding and honoring the sticky header offset
- align the product detail layout gutters with the new wrapper so the galleries stretch edge-to-edge on mobile without double padding
- upgrade the mobile product header to reuse the hybrid scroll/hide logic and expose its height through the shared CSS variable
- smooth out the hybrid header animation so it tracks touch scroll without stutter and remove the shadow from the product header

## Testing
- npm run lint *(fails: Next.js prompts for ESLint config in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e58e4665bc833199864caca3d62377