### PR TITLE
Add admin design system controls and improve navigation URLs

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,5 +1,9 @@
 // prisma/seed.ts
 import { PrismaClient } from '@prisma/client';
+import {
+  DEFAULT_DESIGN_SYSTEM_SETTINGS,
+  DESIGN_SYSTEM_KEY,
+} from '../src/lib/settings/design-system';
 
 const prisma = new PrismaClient();
 
@@ -102,6 +106,13 @@ async function main() {
   await prisma.senderType.createMany({
     data: [{ name: 'CLIENT' }, { name: 'AGENT' }, { name: 'SYSTEM' }],
     skipDuplicates: true,
+  });
+
+  console.log('   - Инициализация дизайн-системы...');
+  await prisma.systemSetting.upsert({
+    where: { key: DESIGN_SYSTEM_KEY },
+    update: { value: JSON.stringify(DEFAULT_DESIGN_SYSTEM_SETTINGS) },
+    create: { key: DESIGN_SYSTEM_KEY, value: JSON.stringify(DEFAULT_DESIGN_SYSTEM_SETTINGS) },
   });
 
   console.log('✅ СИДИНГ ФУНДАМЕНТА УСПЕШНО ЗАВЕРШЕН');

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -3,6 +3,7 @@
 import { notFound } from 'next/navigation';
 import { auth } from '@/lib/auth';
 import AdminHeader from '@/components/admin/AdminHeader';
+import AdminPathNormalizer from '@/components/admin/AdminPathNormalizer';
 
 const ADMIN_ROLES = ['ADMIN', 'MANAGEMENT'];
 
@@ -22,6 +23,7 @@ export default async function AdminLayout({ children }: AdminLayoutProps) {
 
   return (
     <div className="flex min-h-screen flex-col bg-gray-50">
+      <AdminPathNormalizer />
       <AdminHeader />
       {/* --- НАЧАЛО ИЗМЕНЕНИЙ: Добавляем центральный контейнер для всего контента админки --- */}
       <main className="flex-grow">

--- a/src/app/admin/settings/design-system/page.tsx
+++ b/src/app/admin/settings/design-system/page.tsx
@@ -1,0 +1,54 @@
+// Местоположение: src/app/admin/settings/design-system/page.tsx
+
+import { redirect } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import {
+  DEFAULT_DESIGN_SYSTEM_SETTINGS,
+  getDesignSystemSettings,
+} from '@/lib/settings/design-system';
+import DesignSystemForm from '@/components/admin/settings/DesignSystemForm';
+import { ToastViewport } from '@/components/shared/ui';
+
+const ADMIN_ROLES = new Set(['ADMIN', 'MANAGEMENT']);
+
+export const metadata = {
+  title: 'Дизайн-система | Kyanchir Admin',
+};
+
+export default async function DesignSystemSettingsPage() {
+  const session = await auth();
+
+  if (!session?.user?.role?.name || !ADMIN_ROLES.has(session.user.role.name)) {
+    redirect('/admin/login');
+  }
+
+  const { settings, updatedAt } = await getDesignSystemSettings();
+
+  const initialSettings = structuredClone(settings);
+  const defaultSettings = structuredClone(DEFAULT_DESIGN_SYSTEM_SETTINGS);
+
+  return (
+    <div className="space-y-6">
+      <ToastViewport />
+
+      <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <h1 className="text-2xl font-bold text-gray-900">🎨 Конструктор дизайн-системы</h1>
+        <p className="mt-2 text-sm text-gray-600">
+          Настраивайте шрифты, типографику и отступы в одном месте — изменения сразу же подхватываются публичным фронтом
+          через CSS-переменные и tailwind-токены.
+        </p>
+        <p className="mt-4 text-xs text-gray-500">
+          Последнее обновление:{' '}
+          {updatedAt
+            ? new Intl.DateTimeFormat('ru-RU', {
+                dateStyle: 'medium',
+                timeStyle: 'short',
+              }).format(updatedAt)
+            : 'ещё не сохранялось'}
+        </p>
+      </div>
+
+      <DesignSystemForm initialSettings={initialSettings} defaultSettings={defaultSettings} />
+    </div>
+  );
+}

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -1,0 +1,102 @@
+// Местоположение: src/app/admin/settings/page.tsx
+
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { getDesignSystemSettings } from '@/lib/settings/design-system';
+
+const ADMIN_ROLES = new Set(['ADMIN', 'MANAGEMENT']);
+
+export const metadata = {
+  title: 'Настройки проекта | Kyanchir Admin',
+};
+
+export default async function AdminSettingsIndexPage() {
+  const session = await auth();
+
+  if (!session?.user?.role?.name || !ADMIN_ROLES.has(session.user.role.name)) {
+    redirect('/admin/login');
+  }
+
+  const { settings, updatedAt } = await getDesignSystemSettings();
+
+  const formattedUpdatedAt = updatedAt
+    ? new Intl.DateTimeFormat('ru-RU', {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+      }).format(updatedAt)
+    : 'ещё не сохранялось';
+
+  return (
+    <div className="space-y-8">
+      <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <h1 className="text-2xl font-bold text-gray-900">⚙️ Настройки проекта</h1>
+        <p className="mt-2 text-sm text-gray-600">
+          Управляйте ключевыми параметрами бренда, дизайн-системы и интеграций из одного места
+        </p>
+        <dl className="mt-6 grid gap-4 sm:grid-cols-3">
+          <div className="rounded-md border border-gray-100 bg-gray-50 p-4">
+            <dt className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+              Название сайта
+            </dt>
+            <dd className="mt-1 text-lg font-semibold text-gray-900">{settings.siteName}</dd>
+          </div>
+          <div className="rounded-md border border-gray-100 bg-gray-50 p-4">
+            <dt className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+              Основной шрифт
+            </dt>
+            <dd className="mt-1 text-sm text-gray-900">{settings.fonts.body.stack}</dd>
+          </div>
+          <div className="rounded-md border border-gray-100 bg-gray-50 p-4">
+            <dt className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+              Последнее обновление
+            </dt>
+            <dd className="mt-1 text-sm text-gray-900">{formattedUpdatedAt}</dd>
+          </div>
+        </dl>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <div className="flex h-full flex-col justify-between rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+          <div>
+            <h2 className="text-xl font-semibold text-gray-900">🎨 Дизайн-система</h2>
+            <p className="mt-2 text-sm text-gray-600">
+              Централизованное управление типографикой, шрифтами и отступами. Настройки мгновенно превращаются в
+              CSS-переменные и tailwind-токены, доступные во всём проекте.
+            </p>
+            <ul className="mt-4 space-y-2 text-sm text-gray-600">
+              <li>• Название сайта: {settings.siteName}</li>
+              <li>• Стек заголовков: {settings.fonts.heading.stack}</li>
+              <li>• Типографика h1 → h3 и базовый текст</li>
+              <li>• Шкала отступов (xs → 3xl)</li>
+            </ul>
+          </div>
+          <div className="mt-6 flex items-center justify-between border-t border-gray-100 pt-4">
+            <p className="text-xs text-gray-500">
+              Все изменения автоматически прокидываются в публичную часть сайта
+            </p>
+            <Link
+              href="/admin/settings/design-system"
+              className="inline-flex items-center rounded-md bg-gray-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-gray-800"
+            >
+              Открыть конструктор
+            </Link>
+          </div>
+        </div>
+
+        <div className="flex h-full flex-col justify-between rounded-lg border border-dashed border-gray-300 bg-white p-6 text-gray-500 shadow-sm">
+          <div>
+            <h2 className="text-xl font-semibold text-gray-700">🔌 Интеграции (скоро)</h2>
+            <p className="mt-2 text-sm">
+              Управление API-ключами и сервисами. Здесь появятся настройки SendGrid, Telegram-ботов и других интеграций.
+            </p>
+          </div>
+          <div className="mt-6 flex items-center justify-between border-t border-gray-100 pt-4">
+            <p className="text-xs">В разработке</p>
+            <span className="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-500">Coming soon</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/admin/settings/design-system/route.ts
+++ b/src/app/api/admin/settings/design-system/route.ts
@@ -1,0 +1,81 @@
+// Местоположение: src/app/api/admin/settings/design-system/route.ts
+
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { ZodError } from 'zod';
+import { authOptions } from '@/lib/auth';
+import {
+  getDesignSystemSettings,
+  saveDesignSystemSettings,
+  validateDesignSystemPayload,
+} from '@/lib/settings/design-system';
+
+const ALLOWED_ROLES = new Set(['ADMIN', 'MANAGEMENT']);
+
+async function ensureAdmin() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.role?.name || !ALLOWED_ROLES.has(session.user.role.name)) {
+    return null;
+  }
+
+  return session;
+}
+
+export async function GET() {
+  const session = await ensureAdmin();
+
+  if (!session) {
+    return NextResponse.json({ error: 'Доступ запрещён' }, { status: 403 });
+  }
+
+  try {
+    const snapshot = await getDesignSystemSettings();
+
+    return NextResponse.json({ data: snapshot.settings, updatedAt: snapshot.updatedAt });
+  } catch (error) {
+    console.error('[API] Ошибка загрузки настроек дизайн-системы', error);
+    return NextResponse.json(
+      { error: 'Не удалось загрузить настройки дизайн-системы' },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PUT(request: Request) {
+  const session = await ensureAdmin();
+
+  if (!session) {
+    return NextResponse.json({ error: 'Доступ запрещён' }, { status: 403 });
+  }
+
+  try {
+    const payload = await request.json();
+    const parsed = validateDesignSystemPayload(payload);
+    const snapshot = await saveDesignSystemSettings(parsed);
+
+    return NextResponse.json({
+      message: 'Дизайн-система успешно обновлена',
+      data: snapshot.settings,
+      updatedAt: snapshot.updatedAt,
+    });
+  } catch (error) {
+    console.error('[API] Ошибка сохранения дизайн-системы', error);
+
+    if (error instanceof SyntaxError) {
+      return NextResponse.json({ error: 'Некорректный формат запроса' }, { status: 400 });
+    }
+
+    if (error instanceof ZodError) {
+      return NextResponse.json(
+        { error: 'Проверьте заполненные поля', details: error.issues },
+        { status: 422 },
+      );
+    }
+
+    return NextResponse.json(
+      { error: 'Не удалось сохранить настройки дизайн-системы' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -31,7 +31,7 @@
     -webkit-font-smoothing: antialiased;
     background-color: var(--background-primary);
     color: var(--text-primary);
-    font-family: var(--font-body);
+    font-family: var(--ds-font-body, var(--font-body));
     overscroll-behavior-y: contain;
 
     padding-left: env(safe-area-inset-left);
@@ -48,7 +48,7 @@
   }
 
   h1, h2, h3, h4, h5, h6 {
-    font-family: var(--font-heading);
+    font-family: var(--ds-font-heading, var(--font-heading));
     word-break: break-word;
     hyphens: auto;
   }
@@ -58,23 +58,24 @@
   }
 
   h1 {
-    font-size: clamp(2rem, 6vw + 1rem, 6rem);
-    line-height: 1.1;
-    letter-spacing: -0.03em;
-    font-weight: 900;
+    font-size: var(--ds-heading-1-size);
+    line-height: var(--ds-heading-1-line-height);
+    letter-spacing: var(--ds-heading-1-letter-spacing, -0.03em);
+    font-weight: var(--ds-heading-1-weight);
   }
 
   h2 {
-    font-size: clamp(1.75rem, 4vw + 0.5rem, 3.75rem);
-    line-height: 1.2;
-    letter-spacing: -0.02em;
-    font-weight: 800;
+    font-size: var(--ds-heading-2-size);
+    line-height: var(--ds-heading-2-line-height);
+    letter-spacing: var(--ds-heading-2-letter-spacing, -0.02em);
+    font-weight: var(--ds-heading-2-weight);
   }
 
   h3 {
-    font-size: clamp(1.3rem, 3vw + 0.5rem, 2.5rem);
-    line-height: 1.2;
-    font-weight: 700;
+    font-size: var(--ds-heading-3-size);
+    line-height: var(--ds-heading-3-line-height);
+    letter-spacing: var(--ds-heading-3-letter-spacing, 0em);
+    font-weight: var(--ds-heading-3-weight);
   }
 
   h4, h5, h6 {
@@ -82,17 +83,25 @@
   }
 
   p, button {
-    font-size: clamp(1rem, 0.8vw + 0.5rem, 1.125rem);
+    font-size: var(--ds-body-font-size);
   }
 
   p {
-    line-height: 1.6;
-    font-weight: 400;
+    line-height: var(--ds-body-line-height);
+    font-weight: var(--ds-body-font-weight);
+    letter-spacing: var(--ds-body-letter-spacing, 0);
   }
-  
+
   button {
     line-height: 1;
     font-weight: 700;
+  }
+
+  small {
+    font-size: var(--ds-small-font-size);
+    line-height: var(--ds-small-line-height);
+    font-weight: var(--ds-small-font-weight);
+    letter-spacing: var(--ds-small-letter-spacing, 0);
   }
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,15 +5,85 @@ import { fontHeading, fontBody, fontMono } from './fonts';
 import AuthProvider from '@/components/providers/AuthProvider';
 // AppCore был удален отсюда
 import Script from 'next/script';
+import type { Metadata } from 'next';
+import { getDesignSystemSettings } from '@/lib/settings/design-system';
 
-export const metadata = {
-  title: 'Kyanchir',
-  description: 'Мини-приложение / сайт',
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const { settings } = await getDesignSystemSettings();
 
-export default function RootLayout({
+  const description = 'Мини-приложение / сайт';
+
+  return {
+    title: settings.siteName,
+    description,
+    openGraph: {
+      title: settings.siteName,
+      description,
+      siteName: settings.siteName,
+    },
+    twitter: {
+      title: settings.siteName,
+      description,
+    },
+  };
+}
+
+function buildDesignSystemStyle(settings: Awaited<ReturnType<typeof getDesignSystemSettings>>['settings']) {
+  const tokens = [
+    ['--ds-font-heading', settings.fonts.heading.stack],
+    ['--ds-font-body', settings.fonts.body.stack],
+    ['--ds-font-accent', settings.fonts.accent.stack],
+    ['--ds-heading-1-size', settings.typography.h1.size],
+    ['--ds-heading-1-line-height', settings.typography.h1.lineHeight],
+    ['--ds-heading-1-weight', settings.typography.h1.weight],
+    ['--ds-heading-1-letter-spacing', settings.typography.h1.letterSpacing ?? 'normal'],
+    ['--ds-heading-2-size', settings.typography.h2.size],
+    ['--ds-heading-2-line-height', settings.typography.h2.lineHeight],
+    ['--ds-heading-2-weight', settings.typography.h2.weight],
+    ['--ds-heading-2-letter-spacing', settings.typography.h2.letterSpacing ?? 'normal'],
+    ['--ds-heading-3-size', settings.typography.h3.size],
+    ['--ds-heading-3-line-height', settings.typography.h3.lineHeight],
+    ['--ds-heading-3-weight', settings.typography.h3.weight],
+    ['--ds-heading-3-letter-spacing', settings.typography.h3.letterSpacing ?? 'normal'],
+    ['--ds-body-font-size', settings.typography.body.size],
+    ['--ds-body-line-height', settings.typography.body.lineHeight],
+    ['--ds-body-font-weight', settings.typography.body.weight],
+    ['--ds-body-letter-spacing', settings.typography.body.letterSpacing ?? 'normal'],
+    ['--ds-small-font-size', settings.typography.small.size],
+    ['--ds-small-line-height', settings.typography.small.lineHeight],
+    ['--ds-small-font-weight', settings.typography.small.weight],
+    ['--ds-small-letter-spacing', settings.typography.small.letterSpacing ?? 'normal'],
+    ['--ds-spacing-xs', settings.spacing.xs],
+    ['--ds-spacing-sm', settings.spacing.sm],
+    ['--ds-spacing-md', settings.spacing.md],
+    ['--ds-spacing-lg', settings.spacing.lg],
+    ['--ds-spacing-xl', settings.spacing.xl],
+    ['--ds-spacing-2xl', settings.spacing['2xl']],
+    ['--ds-spacing-3xl', settings.spacing['3xl']],
+  ] as const;
+
+  const declarations = tokens
+    .map(([key, value]) => `${key}: ${value};`)
+    .join('\n    ');
+
+  return `:root {\n    ${declarations}\n  }`;
+}
+
+export default async function RootLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
+  const { settings } = await getDesignSystemSettings();
+
+  const fontSources = Array.from(
+    new Set(
+      [settings.fonts.heading.source, settings.fonts.body.source, settings.fonts.accent.source].filter(
+        (value): value is string => Boolean(value),
+      ),
+    ),
+  );
+
+  const designSystemStyle = buildDesignSystemStyle(settings);
+
   return (
     <html
       lang="ru"
@@ -29,6 +99,11 @@ export default function RootLayout({
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="format-detection" content="telephone=no" />
+        <meta name="og:site_name" content={settings.siteName} />
+        {fontSources.map((href) => (
+          <link key={href} rel="stylesheet" href={href} />
+        ))}
+        <style id="design-system-variables" dangerouslySetInnerHTML={{ __html: designSystemStyle }} />
       </head>
 
       <body className="h-full">

--- a/src/components/ClientInteractivity.tsx
+++ b/src/components/ClientInteractivity.tsx
@@ -38,6 +38,44 @@ export default function ClientInteractivity() {
     };
   }, [isMenuOpen]);
 
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const url = new URL(window.location.href);
+    const currentState = url.searchParams.get('menu');
+
+    if (isMenuOpen && currentState !== 'open') {
+      url.searchParams.set('menu', 'open');
+      window.history.replaceState(
+        window.history.state,
+        '',
+        `${url.pathname}${url.search}${url.hash}`,
+      );
+    }
+
+    if (!isMenuOpen && currentState === 'open') {
+      url.searchParams.delete('menu');
+      window.history.replaceState(
+        window.history.state,
+        '',
+        `${url.pathname}${url.search}${url.hash}`,
+      );
+    }
+  }, [isMenuOpen]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const url = new URL(window.location.href);
+    if (url.searchParams.get('menu') === 'open') {
+      setMenuOpen(true);
+    }
+  }, [setMenuOpen]);
+
   // --- НАЧАЛО ИЗМЕНЕНИЙ ---
   // Простая функция-переключатель
   const toggleMenu = () => {

--- a/src/components/FloatingMenuOverlay/AuthenticatedView.tsx
+++ b/src/components/FloatingMenuOverlay/AuthenticatedView.tsx
@@ -123,7 +123,7 @@ const AuthenticatedView = ({
         </Link>
         {user?.role?.name === 'ADMIN' && (
           <Link
-            href="https://admin.kyanchir.ru/dashboard"
+            href="https://admin.kyanchir.ru/"
             onClick={onClose}
             aria-label="Админ-панель"
             className="p-2"

--- a/src/components/admin/AdminPathNormalizer.tsx
+++ b/src/components/admin/AdminPathNormalizer.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+
+const ADMIN_PREFIX = '/admin';
+
+function normalizePath(pathname: string) {
+  if (!pathname.startsWith(ADMIN_PREFIX)) {
+    return null;
+  }
+
+  const normalized = pathname.slice(ADMIN_PREFIX.length) || '/';
+  return normalized.startsWith('/') ? normalized : `/${normalized}`;
+}
+
+export default function AdminPathNormalizer() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const normalized = pathname ? normalizePath(pathname) : null;
+
+    if (!normalized) {
+      return;
+    }
+
+    const { search, hash } = window.location;
+    const target = `${normalized}${search}${hash}`;
+
+    if (window.location.pathname !== normalized) {
+      window.history.replaceState(window.history.state, '', target);
+    }
+  }, [pathname]);
+
+  return null;
+}

--- a/src/components/admin/settings/DesignSystemForm.tsx
+++ b/src/components/admin/settings/DesignSystemForm.tsx
@@ -1,0 +1,464 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { CSSProperties } from 'react';
+import { toast } from 'react-hot-toast';
+import { LoadingButton } from '@/components/shared/ui';
+import { cn } from '@/lib/utils';
+import type { DesignSystemSettings } from '@/lib/settings/design-system';
+
+interface DesignSystemFormProps {
+  initialSettings: DesignSystemSettings;
+  defaultSettings: DesignSystemSettings;
+}
+
+const spacingOrder: Array<keyof DesignSystemSettings['spacing']> = [
+  'xs',
+  'sm',
+  'md',
+  'lg',
+  'xl',
+  '2xl',
+  '3xl',
+];
+
+const typographyOrder: Array<keyof DesignSystemSettings['typography']> = [
+  'h1',
+  'h2',
+  'h3',
+  'body',
+  'small',
+];
+
+const typographyLabels: Record<keyof DesignSystemSettings['typography'], string> = {
+  h1: 'Заголовок H1',
+  h2: 'Заголовок H2',
+  h3: 'Заголовок H3',
+  body: 'Основной текст',
+  small: 'Мелкий текст',
+};
+
+const fontLabels: Record<keyof DesignSystemSettings['fonts'], string> = {
+  heading: 'Заголовки',
+  body: 'Основной текст',
+  accent: 'Акцентный / моно',
+};
+
+function cloneSettings(settings: DesignSystemSettings) {
+  return JSON.parse(JSON.stringify(settings)) as DesignSystemSettings;
+}
+
+function humanizeSpacingKey(key: keyof DesignSystemSettings['spacing']) {
+  if (key === '2xl') return '2XL';
+  if (key === '3xl') return '3XL';
+  return key.toUpperCase();
+}
+
+export default function DesignSystemForm({
+  initialSettings,
+  defaultSettings,
+}: DesignSystemFormProps) {
+  const [settings, setSettings] = useState<DesignSystemSettings>(cloneSettings(initialSettings));
+  const [savedSnapshot, setSavedSnapshot] = useState<DesignSystemSettings>(
+    cloneSettings(initialSettings),
+  );
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    setSettings(cloneSettings(initialSettings));
+    setSavedSnapshot(cloneSettings(initialSettings));
+  }, [initialSettings]);
+
+  const isDirty = useMemo(
+    () => JSON.stringify(settings) !== JSON.stringify(savedSnapshot),
+    [settings, savedSnapshot],
+  );
+
+  const previewStyle = useMemo(() => {
+    return {
+      '--ds-font-heading': settings.fonts.heading.stack,
+      '--ds-font-body': settings.fonts.body.stack,
+      '--ds-font-accent': settings.fonts.accent.stack,
+      '--ds-heading-1-size': settings.typography.h1.size,
+      '--ds-heading-1-line-height': settings.typography.h1.lineHeight,
+      '--ds-heading-1-weight': settings.typography.h1.weight,
+      '--ds-heading-1-letter-spacing': settings.typography.h1.letterSpacing ?? 'normal',
+      '--ds-heading-2-size': settings.typography.h2.size,
+      '--ds-heading-2-line-height': settings.typography.h2.lineHeight,
+      '--ds-heading-2-weight': settings.typography.h2.weight,
+      '--ds-heading-2-letter-spacing': settings.typography.h2.letterSpacing ?? 'normal',
+      '--ds-heading-3-size': settings.typography.h3.size,
+      '--ds-heading-3-line-height': settings.typography.h3.lineHeight,
+      '--ds-heading-3-weight': settings.typography.h3.weight,
+      '--ds-heading-3-letter-spacing': settings.typography.h3.letterSpacing ?? 'normal',
+      '--ds-body-font-size': settings.typography.body.size,
+      '--ds-body-line-height': settings.typography.body.lineHeight,
+      '--ds-body-font-weight': settings.typography.body.weight,
+      '--ds-body-letter-spacing': settings.typography.body.letterSpacing ?? 'normal',
+      '--ds-small-font-size': settings.typography.small.size,
+      '--ds-small-line-height': settings.typography.small.lineHeight,
+      '--ds-small-font-weight': settings.typography.small.weight,
+      '--ds-small-letter-spacing': settings.typography.small.letterSpacing ?? 'normal',
+      '--ds-spacing-xs': settings.spacing.xs,
+      '--ds-spacing-sm': settings.spacing.sm,
+      '--ds-spacing-md': settings.spacing.md,
+      '--ds-spacing-lg': settings.spacing.lg,
+      '--ds-spacing-xl': settings.spacing.xl,
+      '--ds-spacing-2xl': settings.spacing['2xl'],
+      '--ds-spacing-3xl': settings.spacing['3xl'],
+    } as CSSProperties;
+  }, [settings]);
+
+  const handleSiteNameChange = useCallback((value: string) => {
+    setSettings((prev) => ({ ...prev, siteName: value }));
+  }, []);
+
+  const handleFontChange = useCallback(
+    (fontKey: keyof DesignSystemSettings['fonts'], field: 'stack' | 'source', value: string) => {
+      setSettings((prev) => ({
+        ...prev,
+        fonts: {
+          ...prev.fonts,
+          [fontKey]: {
+            ...prev.fonts[fontKey],
+            [field]: value,
+          },
+        },
+      }));
+    },
+    [],
+  );
+
+  const handleTypographyChange = useCallback(
+    (
+      token: keyof DesignSystemSettings['typography'],
+      field: keyof DesignSystemSettings['typography']['h1'],
+      value: string,
+    ) => {
+      setSettings((prev) => ({
+        ...prev,
+        typography: {
+          ...prev.typography,
+          [token]: {
+            ...prev.typography[token],
+            [field]: value,
+          },
+        },
+      }));
+    },
+    [],
+  );
+
+  const handleSpacingChange = useCallback(
+    (spacingKey: keyof DesignSystemSettings['spacing'], value: string) => {
+      setSettings((prev) => ({
+        ...prev,
+        spacing: {
+          ...prev.spacing,
+          [spacingKey]: value,
+        },
+      }));
+    },
+    [],
+  );
+
+  const handleResetToDefaults = useCallback(() => {
+    setSettings(cloneSettings(defaultSettings));
+  }, [defaultSettings]);
+
+  const handleRevert = useCallback(() => {
+    setSettings(cloneSettings(savedSnapshot));
+  }, [savedSnapshot]);
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      setIsSaving(true);
+
+      try {
+        const response = await fetch('/api/admin/settings/design-system', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(settings),
+        });
+
+        const data = await response.json();
+
+        if (!response.ok) {
+          throw new Error(data?.error ?? 'Не удалось сохранить дизайн-систему');
+        }
+
+        if (!data?.data) {
+          throw new Error('Сервер не вернул данные дизайн-системы');
+        }
+
+        const nextSettings = cloneSettings(data.data as DesignSystemSettings);
+        setSettings(nextSettings);
+        setSavedSnapshot(nextSettings);
+        toast.success('Дизайн-система обновлена');
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Неизвестная ошибка сохранения';
+        toast.error(message);
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [settings],
+  );
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-10">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900">Управление токенами</h2>
+          <p className="text-sm text-gray-600">
+            Все значения автоматически нормализуются и сохраняются в таблице SystemSetting
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            onClick={handleResetToDefaults}
+            className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:border-gray-400 hover:text-gray-900"
+          >
+            Сбросить к дефолту
+          </button>
+          <button
+            type="button"
+            onClick={handleRevert}
+            disabled={!isDirty}
+            className={cn(
+              'rounded-md border border-gray-300 px-4 py-2 text-sm font-medium transition',
+              isDirty
+                ? 'text-gray-700 hover:border-gray-400 hover:text-gray-900'
+                : 'cursor-not-allowed text-gray-400',
+            )}
+          >
+            Отменить изменения
+          </button>
+          <LoadingButton
+            type="submit"
+            isLoading={isSaving}
+            disabled={!isDirty}
+            className={cn(
+              'bg-gray-900 text-white hover:bg-gray-800',
+              !isDirty && !isSaving && 'cursor-not-allowed opacity-60',
+            )}
+          >
+            Сохранить
+          </LoadingButton>
+        </div>
+      </div>
+
+      <section className="grid gap-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <h3 className="text-lg font-semibold text-gray-900">Идентика</h3>
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="flex flex-col space-y-1">
+            <span className="text-sm font-medium text-gray-700">Название сайта</span>
+            <input
+              type="text"
+              value={settings.siteName}
+              onChange={(event) => handleSiteNameChange(event.target.value)}
+              placeholder="Например: Kyanchir"
+              className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300"
+              maxLength={60}
+            />
+            <span className="text-xs text-gray-500">
+              Используется в metadata и заголовках публичной части
+            </span>
+          </label>
+        </div>
+      </section>
+
+      <section className="grid gap-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900">Шрифтовые стеки</h3>
+          <p className="mt-1 text-sm text-gray-600">
+            Укажите CSS-стек шрифтов. Если используете кастомный источник, добавьте ссылку на Google Fonts или
+            собственный CSS.
+          </p>
+        </div>
+        <div className="grid gap-6 md:grid-cols-3">
+          {Object.keys(fontLabels).map((fontKey) => {
+            const key = fontKey as keyof DesignSystemSettings['fonts'];
+            const font = settings.fonts[key];
+            return (
+              <div key={key} className="space-y-3 rounded-md border border-gray-100 bg-gray-50 p-4">
+                <div>
+                  <p className="text-sm font-semibold text-gray-900">{fontLabels[key]}</p>
+                  <p className="text-xs text-gray-500">CSS-стек и опциональный источник</p>
+                </div>
+                <label className="flex flex-col space-y-1">
+                  <span className="text-xs font-medium text-gray-600">Стек шрифтов</span>
+                  <textarea
+                    value={font.stack}
+                    onChange={(event) => handleFontChange(key, 'stack', event.target.value)}
+                    className="min-h-[72px] rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300"
+                    placeholder='var(--font-heading), "Unbounded", sans-serif'
+                  />
+                </label>
+                <label className="flex flex-col space-y-1">
+                  <span className="text-xs font-medium text-gray-600">Источник (опционально)</span>
+                  <input
+                    type="url"
+                    value={font.source ?? ''}
+                    onChange={(event) => handleFontChange(key, 'source', event.target.value)}
+                    placeholder="https://fonts.googleapis.com/..."
+                    className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300"
+                  />
+                </label>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="grid gap-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900">Типографика</h3>
+          <p className="mt-1 text-sm text-gray-600">
+            Значения используются как CSS-переменные и доступны в tailwind как классы text-ds-*
+          </p>
+        </div>
+        <div className="grid gap-4">
+          {typographyOrder.map((tokenKey) => {
+            const token = settings.typography[tokenKey];
+            return (
+              <div
+                key={tokenKey}
+                className="grid gap-3 rounded-md border border-gray-100 bg-gray-50 p-4 md:grid-cols-4"
+              >
+                <div>
+                  <p className="text-sm font-semibold text-gray-900">{typographyLabels[tokenKey]}</p>
+                  <p className="text-xs text-gray-500">font-size, line-height, weight, letter-spacing</p>
+                </div>
+                <label className="flex flex-col space-y-1">
+                  <span className="text-xs font-medium text-gray-600">Размер</span>
+                  <input
+                    type="text"
+                    value={token.size}
+                    onChange={(event) =>
+                      handleTypographyChange(tokenKey, 'size', event.target.value)
+                    }
+                    className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300"
+                  />
+                </label>
+                <label className="flex flex-col space-y-1">
+                  <span className="text-xs font-medium text-gray-600">Line-height</span>
+                  <input
+                    type="text"
+                    value={token.lineHeight}
+                    onChange={(event) =>
+                      handleTypographyChange(tokenKey, 'lineHeight', event.target.value)
+                    }
+                    className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300"
+                  />
+                </label>
+                <div className="grid gap-3 md:grid-cols-2">
+                  <label className="flex flex-col space-y-1">
+                    <span className="text-xs font-medium text-gray-600">Вес</span>
+                    <input
+                      type="text"
+                      value={token.weight}
+                      onChange={(event) =>
+                        handleTypographyChange(tokenKey, 'weight', event.target.value)
+                      }
+                      className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300"
+                    />
+                  </label>
+                  <label className="flex flex-col space-y-1">
+                    <span className="text-xs font-medium text-gray-600">Letter-spacing</span>
+                    <input
+                      type="text"
+                      value={token.letterSpacing ?? ''}
+                      onChange={(event) =>
+                        handleTypographyChange(tokenKey, 'letterSpacing', event.target.value)
+                      }
+                      placeholder="например, -0.02em"
+                      className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300"
+                    />
+                  </label>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="grid gap-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900">Шкала отступов</h3>
+          <p className="mt-1 text-sm text-gray-600">
+            Значения используются как CSS-переменные и доступны в tailwind как spacing ds-*
+          </p>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-4">
+            {spacingOrder.map((spacingKey) => (
+              <label key={spacingKey} className="flex items-center justify-between gap-4">
+                <div>
+                  <span className="block text-sm font-medium text-gray-700">
+                    {humanizeSpacingKey(spacingKey)}
+                  </span>
+                  <span className="block text-xs text-gray-500">Класс: gap-ds-{spacingKey}</span>
+                </div>
+                <input
+                  type="text"
+                  value={settings.spacing[spacingKey]}
+                  onChange={(event) => handleSpacingChange(spacingKey, event.target.value)}
+                  className="w-32 rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300"
+                />
+              </label>
+            ))}
+          </div>
+          <div className="space-y-3 rounded-md border border-gray-100 bg-gray-50 p-4">
+            <p className="text-sm font-semibold text-gray-900">Превью шкалы</p>
+            <div className="space-y-3">
+              {spacingOrder.map((spacingKey) => (
+                <div key={spacingKey} className="flex items-center gap-3">
+                  <span className="w-10 text-xs font-medium text-gray-500">
+                    {humanizeSpacingKey(spacingKey)}
+                  </span>
+                  <div className="h-2 rounded bg-gray-300" style={{ width: `calc(${settings.spacing[spacingKey]} * 6)` }} />
+                  <span className="text-xs text-gray-500">{settings.spacing[spacingKey]}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <h3 className="text-lg font-semibold text-gray-900">Превью дизайн-системы</h3>
+        <p className="mt-1 text-sm text-gray-600">
+          Секция показывает, как текущие токены повлияют на типографику и отступы.
+        </p>
+        <div style={previewStyle} className="mt-6 space-y-6 rounded-md border border-gray-100 bg-gray-50 p-6">
+          <div className="space-y-2">
+            <h1>Kyanchir Design Tokens</h1>
+            <h2>Гибкая система, управляемая из админки</h2>
+            <h3>Предпросмотр заголовка третьего уровня</h3>
+            <p>
+              Это пример абзаца, который использует переменные дизайн-системы. Все значения для размера, line-height и
+              межбуквенного интервала берутся из токенов, которые вы сохраняете.
+            </p>
+            <small>Мелкий текст, например для вспомогательных подписей и тултипов.</small>
+          </div>
+          <div className="space-y-4">
+            <p className="text-sm font-semibold text-gray-700">Шкала отступов</p>
+            <div className="flex flex-wrap gap-ds-sm rounded-md border border-dashed border-gray-300 p-ds-md">
+              {spacingOrder.map((spacingKey) => (
+                <div
+                  key={spacingKey}
+                  className="flex h-10 w-24 items-center justify-center rounded-md bg-white text-xs text-gray-600 shadow-sm"
+                >
+                  {spacingKey}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+    </form>
+  );
+}

--- a/src/components/admin/users/UsersTable.tsx
+++ b/src/components/admin/users/UsersTable.tsx
@@ -72,14 +72,15 @@ export default function UsersTable({
   const [refreshKey, setRefreshKey] = useState(0);
 
   const debouncedSearch = useDebounce(search, 400, { maxWait: 1200 });
+  const handleRetryToast = useCallback((attempt: number) => {
+    toast.loading(`Повторная попытка загрузки (${attempt + 1})...`, {
+      id: 'users-retry',
+    });
+  }, []);
   const { execute } = useRetry({
     retries: 2,
     delay: 600,
-    onRetry: (attempt) => {
-      toast.loading(`Повторная попытка загрузки (${attempt + 1})...`, {
-        id: 'users-retry',
-      });
-    },
+    onRetry: handleRetryToast,
   });
 
   useEffect(() => {

--- a/src/lib/settings/design-system.ts
+++ b/src/lib/settings/design-system.ts
@@ -1,0 +1,274 @@
+import 'server-only';
+
+import { cache } from 'react';
+import { unstable_noStore as noStore } from 'next/cache';
+import { z } from 'zod';
+import prisma from '@/lib/prisma';
+
+const DESIGN_SYSTEM_KEY = 'DESIGN_SYSTEM';
+
+const fontStackSchema = z.object({
+  stack: z
+    .string()
+    .min(1, 'Укажите хотя бы один шрифт')
+    .max(300, 'Слишком длинное значение стека шрифтов')
+    .transform((value) => value.trim()),
+  source: z
+    .string()
+    .trim()
+    .url('Источник должен быть ссылкой')
+    .optional()
+    .or(z.literal('').transform(() => undefined)),
+});
+
+const typographyTokenSchema = z.object({
+  size: z
+    .string()
+    .min(1, 'Размер обязателен')
+    .max(40, 'Слишком длинное значение размера')
+    .transform((value) => value.trim()),
+  lineHeight: z
+    .string()
+    .min(1, 'Укажите line-height')
+    .max(40, 'Слишком длинное значение line-height')
+    .transform((value) => value.trim()),
+  weight: z
+    .string()
+    .min(1, 'Укажите насыщенность')
+    .max(12, 'Слишком длинное значение насыщенности')
+    .transform((value) => value.trim()),
+  letterSpacing: z
+    .string()
+    .max(20, 'Слишком длинное значение трекинга')
+    .transform((value) => value.trim())
+    .optional(),
+});
+
+const spacingSchema = z.object({
+  xs: z
+    .string()
+    .min(1)
+    .max(15)
+    .transform((value) => value.trim()),
+  sm: z
+    .string()
+    .min(1)
+    .max(15)
+    .transform((value) => value.trim()),
+  md: z
+    .string()
+    .min(1)
+    .max(15)
+    .transform((value) => value.trim()),
+  lg: z
+    .string()
+    .min(1)
+    .max(15)
+    .transform((value) => value.trim()),
+  xl: z
+    .string()
+    .min(1)
+    .max(15)
+    .transform((value) => value.trim()),
+  '2xl': z
+    .string()
+    .min(1)
+    .max(15)
+    .transform((value) => value.trim()),
+  '3xl': z
+    .string()
+    .min(1)
+    .max(15)
+    .transform((value) => value.trim()),
+});
+
+const designSystemSchema = z.object({
+  siteName: z
+    .string()
+    .min(2, 'Название сайта должно быть длиннее')
+    .max(60, 'Название сайта слишком длинное')
+    .transform((value) => value.trim()),
+  fonts: z.object({
+    heading: fontStackSchema,
+    body: fontStackSchema,
+    accent: fontStackSchema,
+  }),
+  typography: z.object({
+    h1: typographyTokenSchema,
+    h2: typographyTokenSchema,
+    h3: typographyTokenSchema,
+    body: typographyTokenSchema,
+    small: typographyTokenSchema,
+  }),
+  spacing: spacingSchema,
+});
+
+export type DesignSystemSettings = z.infer<typeof designSystemSchema>;
+
+export interface DesignSystemSnapshot {
+  settings: DesignSystemSettings;
+  updatedAt: Date | null;
+}
+
+export const DEFAULT_DESIGN_SYSTEM_SETTINGS: DesignSystemSettings = {
+  siteName: 'Kyanchir',
+  fonts: {
+    heading: {
+      stack: 'var(--font-heading), "Unbounded", sans-serif',
+    },
+    body: {
+      stack: 'var(--font-body), "Manrope", sans-serif',
+    },
+    accent: {
+      stack: 'var(--font-mono), "PT Mono", monospace',
+    },
+  },
+  typography: {
+    h1: {
+      size: 'clamp(2rem, 6vw + 1rem, 6rem)',
+      lineHeight: '1.1',
+      weight: '900',
+      letterSpacing: '-0.03em',
+    },
+    h2: {
+      size: 'clamp(1.75rem, 4vw + 0.5rem, 3.75rem)',
+      lineHeight: '1.2',
+      weight: '800',
+      letterSpacing: '-0.02em',
+    },
+    h3: {
+      size: 'clamp(1.3rem, 3vw + 0.5rem, 2.5rem)',
+      lineHeight: '1.2',
+      weight: '700',
+      letterSpacing: '-0.01em',
+    },
+    body: {
+      size: 'clamp(1rem, 0.8vw + 0.5rem, 1.125rem)',
+      lineHeight: '1.6',
+      weight: '400',
+      letterSpacing: '0em',
+    },
+    small: {
+      size: '0.875rem',
+      lineHeight: '1.45',
+      weight: '500',
+      letterSpacing: '0em',
+    },
+  },
+  spacing: {
+    xs: '0.25rem',
+    sm: '0.5rem',
+    md: '1rem',
+    lg: '1.5rem',
+    xl: '2rem',
+    '2xl': '3rem',
+    '3xl': '4rem',
+  },
+};
+
+function mergeWithDefaults(
+  value: Partial<DesignSystemSettings> | null | undefined,
+): DesignSystemSettings {
+  if (!value) {
+    return { ...DEFAULT_DESIGN_SYSTEM_SETTINGS };
+  }
+
+  return {
+    siteName: value.siteName ?? DEFAULT_DESIGN_SYSTEM_SETTINGS.siteName,
+    fonts: {
+      heading: {
+        stack:
+          value.fonts?.heading?.stack ??
+          DEFAULT_DESIGN_SYSTEM_SETTINGS.fonts.heading.stack,
+        source: value.fonts?.heading?.source,
+      },
+      body: {
+        stack:
+          value.fonts?.body?.stack ?? DEFAULT_DESIGN_SYSTEM_SETTINGS.fonts.body.stack,
+        source: value.fonts?.body?.source,
+      },
+      accent: {
+        stack:
+          value.fonts?.accent?.stack ??
+          DEFAULT_DESIGN_SYSTEM_SETTINGS.fonts.accent.stack,
+        source: value.fonts?.accent?.source,
+      },
+    },
+    typography: {
+      h1: { ...DEFAULT_DESIGN_SYSTEM_SETTINGS.typography.h1, ...value.typography?.h1 },
+      h2: { ...DEFAULT_DESIGN_SYSTEM_SETTINGS.typography.h2, ...value.typography?.h2 },
+      h3: { ...DEFAULT_DESIGN_SYSTEM_SETTINGS.typography.h3, ...value.typography?.h3 },
+      body: {
+        ...DEFAULT_DESIGN_SYSTEM_SETTINGS.typography.body,
+        ...value.typography?.body,
+      },
+      small: {
+        ...DEFAULT_DESIGN_SYSTEM_SETTINGS.typography.small,
+        ...value.typography?.small,
+      },
+    },
+    spacing: {
+      xs: value.spacing?.xs ?? DEFAULT_DESIGN_SYSTEM_SETTINGS.spacing.xs,
+      sm: value.spacing?.sm ?? DEFAULT_DESIGN_SYSTEM_SETTINGS.spacing.sm,
+      md: value.spacing?.md ?? DEFAULT_DESIGN_SYSTEM_SETTINGS.spacing.md,
+      lg: value.spacing?.lg ?? DEFAULT_DESIGN_SYSTEM_SETTINGS.spacing.lg,
+      xl: value.spacing?.xl ?? DEFAULT_DESIGN_SYSTEM_SETTINGS.spacing.xl,
+      '2xl': value.spacing?.['2xl'] ?? DEFAULT_DESIGN_SYSTEM_SETTINGS.spacing['2xl'],
+      '3xl': value.spacing?.['3xl'] ?? DEFAULT_DESIGN_SYSTEM_SETTINGS.spacing['3xl'],
+    },
+  };
+}
+
+function safeParseSettings(value: string | null): DesignSystemSettings {
+  if (!value) {
+    return { ...DEFAULT_DESIGN_SYSTEM_SETTINGS };
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    const result = designSystemSchema.deepPartial().parse(parsed);
+    return mergeWithDefaults(result);
+  } catch (error) {
+    console.error('[DesignSystem] Failed to parse settings, fallback to defaults', error);
+    return { ...DEFAULT_DESIGN_SYSTEM_SETTINGS };
+  }
+}
+
+export const getDesignSystemSettings = cache(async (): Promise<DesignSystemSnapshot> => {
+  noStore();
+
+  const record = await prisma.systemSetting.findUnique({
+    where: { key: DESIGN_SYSTEM_KEY },
+  });
+
+  const settings = safeParseSettings(record?.value ?? null);
+
+  return {
+    settings,
+    updatedAt: record?.updatedAt ?? null,
+  };
+});
+
+export async function saveDesignSystemSettings(
+  payload: DesignSystemSettings,
+): Promise<DesignSystemSnapshot> {
+  const normalized = designSystemSchema.parse(payload);
+
+  const record = await prisma.systemSetting.upsert({
+    where: { key: DESIGN_SYSTEM_KEY },
+    update: { value: JSON.stringify(normalized) },
+    create: { key: DESIGN_SYSTEM_KEY, value: JSON.stringify(normalized) },
+  });
+
+  return {
+    settings: mergeWithDefaults(normalized),
+    updatedAt: record.updatedAt,
+  };
+}
+
+export function validateDesignSystemPayload(input: unknown): DesignSystemSettings {
+  const parsed = designSystemSchema.parse(input);
+  return parsed;
+}
+
+export { DESIGN_SYSTEM_KEY };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -36,9 +36,9 @@ const config: Config = {
       },
       // "Набор фирменных шрифтов"
       fontFamily: {
-        heading: ['var(--font-heading)', 'sans-serif'],
-        body: ['var(--font-body)', 'sans-serif'],
-        mono: ['var(--font-mono)', 'monospace'],
+        heading: ['var(--ds-font-heading, var(--font-heading))', 'sans-serif'],
+        body: ['var(--ds-font-body, var(--font-body))', 'sans-serif'],
+        mono: ['var(--ds-font-accent, var(--font-mono))', 'monospace'],
       },
       // "Типографика"
       fontSize: {
@@ -47,6 +47,55 @@ const config: Config = {
           'clamp(0.8rem, 3vw, 1.25rem)',
           { lineHeight: '1.2' },
         ],
+        'ds-h1': [
+          'var(--ds-heading-1-size)',
+          {
+            lineHeight: 'var(--ds-heading-1-line-height)',
+            letterSpacing: 'var(--ds-heading-1-letter-spacing, -0.03em)',
+            fontWeight: 'var(--ds-heading-1-weight)',
+          },
+        ],
+        'ds-h2': [
+          'var(--ds-heading-2-size)',
+          {
+            lineHeight: 'var(--ds-heading-2-line-height)',
+            letterSpacing: 'var(--ds-heading-2-letter-spacing, -0.02em)',
+            fontWeight: 'var(--ds-heading-2-weight)',
+          },
+        ],
+        'ds-h3': [
+          'var(--ds-heading-3-size)',
+          {
+            lineHeight: 'var(--ds-heading-3-line-height)',
+            letterSpacing: 'var(--ds-heading-3-letter-spacing, 0)',
+            fontWeight: 'var(--ds-heading-3-weight)',
+          },
+        ],
+        'ds-body': [
+          'var(--ds-body-font-size)',
+          {
+            lineHeight: 'var(--ds-body-line-height)',
+            letterSpacing: 'var(--ds-body-letter-spacing, 0)',
+            fontWeight: 'var(--ds-body-font-weight)',
+          },
+        ],
+        'ds-small': [
+          'var(--ds-small-font-size)',
+          {
+            lineHeight: 'var(--ds-small-line-height)',
+            letterSpacing: 'var(--ds-small-letter-spacing, 0)',
+            fontWeight: 'var(--ds-small-font-weight)',
+          },
+        ],
+      },
+      spacing: {
+        'ds-xs': 'var(--ds-spacing-xs)',
+        'ds-sm': 'var(--ds-spacing-sm)',
+        'ds-md': 'var(--ds-spacing-md)',
+        'ds-lg': 'var(--ds-spacing-lg)',
+        'ds-xl': 'var(--ds-spacing-xl)',
+        'ds-2xl': 'var(--ds-spacing-2xl)',
+        'ds-3xl': 'var(--ds-spacing-3xl)',
       },
       typographyStyles: ({ theme }: { theme: any }) => ({
         h1: {


### PR DESCRIPTION
## Summary
- add design system settings storage with Prisma helpers and API for admins
- expose a new admin settings hub and design system editor with live previews and Tailwind token guidance
- apply design system tokens at runtime, extend Tailwind spacing/typography, normalize admin URLs, and fix repeated user table fetches

## Testing
- `npm run lint` *(fails: command prompts to configure ESLint interactively in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e595ac629083319d40e736258a2e8b