### PR TITLE
Refactor admin design system controls

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,5 +1,9 @@
 // prisma/seed.ts
 import { PrismaClient } from '@prisma/client';
+import {
+  DEFAULT_DESIGN_SYSTEM_SETTINGS,
+  DESIGN_SYSTEM_KEY,
+} from '../src/lib/settings/design-system';
 
 const prisma = new PrismaClient();
 
@@ -102,6 +106,13 @@ async function main() {
   await prisma.senderType.createMany({
     data: [{ name: 'CLIENT' }, { name: 'AGENT' }, { name: 'SYSTEM' }],
     skipDuplicates: true,
+  });
+
+  console.log('   - Инициализация дизайн-системы...');
+  await prisma.systemSetting.upsert({
+    where: { key: DESIGN_SYSTEM_KEY },
+    update: { value: JSON.stringify(DEFAULT_DESIGN_SYSTEM_SETTINGS) },
+    create: { key: DESIGN_SYSTEM_KEY, value: JSON.stringify(DEFAULT_DESIGN_SYSTEM_SETTINGS) },
   });
 
   console.log('✅ СИДИНГ ФУНДАМЕНТА УСПЕШНО ЗАВЕРШЕН');

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -3,6 +3,7 @@
 import { notFound } from 'next/navigation';
 import { auth } from '@/lib/auth';
 import AdminHeader from '@/components/admin/AdminHeader';
+import AdminPathNormalizer from '@/components/admin/AdminPathNormalizer';
 
 const ADMIN_ROLES = ['ADMIN', 'MANAGEMENT'];
 
@@ -22,6 +23,7 @@ export default async function AdminLayout({ children }: AdminLayoutProps) {
 
   return (
     <div className="flex min-h-screen flex-col bg-gray-50">
+      <AdminPathNormalizer />
       <AdminHeader />
       {/* --- НАЧАЛО ИЗМЕНЕНИЙ: Добавляем центральный контейнер для всего контента админки --- */}
       <main className="flex-grow">

--- a/src/app/admin/settings/design-system/page.tsx
+++ b/src/app/admin/settings/design-system/page.tsx
@@ -1,0 +1,60 @@
+// Местоположение: src/app/admin/settings/design-system/page.tsx
+
+import { redirect } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import {
+  DEFAULT_DESIGN_SYSTEM_SETTINGS,
+  getDesignSystemSettings,
+} from '@/lib/settings/design-system';
+import DesignSystemForm from '@/components/admin/settings/DesignSystemForm';
+import { ToastViewport } from '@/components/shared/ui';
+import { buildIconCatalog } from '@/lib/icons/catalog';
+
+const ADMIN_ROLES = new Set(['ADMIN', 'MANAGEMENT']);
+
+export const metadata = {
+  title: 'Дизайн-система | Kyanchir Admin',
+};
+
+export default async function DesignSystemSettingsPage() {
+  const session = await auth();
+
+  if (!session?.user?.role?.name || !ADMIN_ROLES.has(session.user.role.name)) {
+    redirect('/admin/login');
+  }
+
+  const { settings, updatedAt } = await getDesignSystemSettings();
+
+  const initialSettings = structuredClone(settings);
+  const defaultSettings = structuredClone(DEFAULT_DESIGN_SYSTEM_SETTINGS);
+  const iconCatalog = buildIconCatalog();
+
+  return (
+    <div className="space-y-6">
+      <ToastViewport />
+
+      <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <h1 className="text-2xl font-bold text-gray-900">🎨 Конструктор дизайн-системы</h1>
+        <p className="mt-2 text-sm text-gray-600">
+          Настраивайте шрифты, типографику и отступы в одном месте — изменения сразу же подхватываются публичным фронтом
+          через CSS-переменные и tailwind-токены.
+        </p>
+        <p className="mt-4 text-xs text-gray-500">
+          Последнее обновление:{' '}
+          {updatedAt
+            ? new Intl.DateTimeFormat('ru-RU', {
+                dateStyle: 'medium',
+                timeStyle: 'short',
+              }).format(updatedAt)
+            : 'ещё не сохранялось'}
+        </p>
+      </div>
+
+      <DesignSystemForm
+        initialSettings={initialSettings}
+        defaultSettings={defaultSettings}
+        icons={iconCatalog}
+      />
+    </div>
+  );
+}

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -1,0 +1,117 @@
+// Местоположение: src/app/admin/settings/page.tsx
+
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { getDesignSystemSettings } from '@/lib/settings/design-system';
+import {
+  buildFontStack,
+  ensureFontLibraryIntegrity,
+  getFontById,
+} from '@/lib/settings/design-system.shared';
+
+const ADMIN_ROLES = new Set(['ADMIN', 'MANAGEMENT']);
+
+export const metadata = {
+  title: 'Настройки проекта | Kyanchir Admin',
+};
+
+export default async function AdminSettingsIndexPage() {
+  const session = await auth();
+
+  if (!session?.user?.role?.name || !ADMIN_ROLES.has(session.user.role.name)) {
+    redirect('/admin/login');
+  }
+
+  const { settings, updatedAt } = await getDesignSystemSettings();
+
+  const formattedUpdatedAt = updatedAt
+    ? new Intl.DateTimeFormat('ru-RU', {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+      }).format(updatedAt)
+    : 'ещё не сохранялось';
+
+  const fontLibrary = ensureFontLibraryIntegrity(settings.fontLibrary);
+  const bodyFont = getFontById(fontLibrary, settings.fonts.body);
+  const headingFont = getFontById(fontLibrary, settings.fonts.heading);
+  const accentFont = getFontById(fontLibrary, settings.fonts.accent);
+  const bodyStack = bodyFont ? buildFontStack(bodyFont) : '—';
+  const headingName = headingFont?.name ?? 'Manrope';
+  const accentName = accentFont?.name ?? 'PT Mono';
+
+  return (
+    <div className="space-y-8">
+      <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <h1 className="text-2xl font-bold text-gray-900">⚙️ Настройки проекта</h1>
+        <p className="mt-2 text-sm text-gray-600">
+          Управляйте ключевыми параметрами бренда, дизайн-системы и интеграций из одного места
+        </p>
+        <dl className="mt-6 grid gap-4 sm:grid-cols-3">
+          <div className="rounded-md border border-gray-100 bg-gray-50 p-4">
+            <dt className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+              Название сайта
+            </dt>
+            <dd className="mt-1 text-lg font-semibold text-gray-900">{settings.siteName}</dd>
+          </div>
+          <div className="rounded-md border border-gray-100 bg-gray-50 p-4">
+            <dt className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+              Основной шрифт
+            </dt>
+            <dd className="mt-1 text-sm text-gray-900">{bodyStack}</dd>
+          </div>
+          <div className="rounded-md border border-gray-100 bg-gray-50 p-4">
+            <dt className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+              Последнее обновление
+            </dt>
+            <dd className="mt-1 text-sm text-gray-900">{formattedUpdatedAt}</dd>
+          </div>
+        </dl>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <div className="flex h-full flex-col justify-between rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+          <div>
+            <h2 className="text-xl font-semibold text-gray-900">🎨 Дизайн-система</h2>
+            <p className="mt-2 text-sm text-gray-600">
+              Централизованное управление типографикой, шрифтами и отступами. Настройки мгновенно превращаются в
+              CSS-переменные и tailwind-токены, доступные во всём проекте.
+            </p>
+            <ul className="mt-4 space-y-2 text-sm text-gray-600">
+              <li>• Название сайта: {settings.siteName}</li>
+              <li>• Заголовки: {headingName}</li>
+              <li>• Основной текст: {bodyFont?.name ?? 'Manrope'}</li>
+              <li>• Акценты и моно: {accentName}</li>
+              <li>• Типографика h1 → h3 и базовый текст</li>
+              <li>• Шкала отступов (xs → 3xl)</li>
+            </ul>
+          </div>
+          <div className="mt-6 flex items-center justify-between border-t border-gray-100 pt-4">
+            <p className="text-xs text-gray-500">
+              Все изменения автоматически прокидываются в публичную часть сайта
+            </p>
+            <Link
+              href="/admin/settings/design-system"
+              className="inline-flex items-center rounded-md bg-gray-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-gray-800"
+            >
+              Открыть конструктор
+            </Link>
+          </div>
+        </div>
+
+        <div className="flex h-full flex-col justify-between rounded-lg border border-dashed border-gray-300 bg-white p-6 text-gray-500 shadow-sm">
+          <div>
+            <h2 className="text-xl font-semibold text-gray-700">🔌 Интеграции (скоро)</h2>
+            <p className="mt-2 text-sm">
+              Управление API-ключами и сервисами. Здесь появятся настройки SendGrid, Telegram-ботов и других интеграций.
+            </p>
+          </div>
+          <div className="mt-6 flex items-center justify-between border-t border-gray-100 pt-4">
+            <p className="text-xs">В разработке</p>
+            <span className="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-500">Coming soon</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/admin/settings/design-system/route.ts
+++ b/src/app/api/admin/settings/design-system/route.ts
@@ -1,0 +1,81 @@
+// Местоположение: src/app/api/admin/settings/design-system/route.ts
+
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { ZodError } from 'zod';
+import { authOptions } from '@/lib/auth';
+import {
+  getDesignSystemSettings,
+  saveDesignSystemSettings,
+  validateDesignSystemPayload,
+} from '@/lib/settings/design-system';
+
+const ALLOWED_ROLES = new Set(['ADMIN', 'MANAGEMENT']);
+
+async function ensureAdmin() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.role?.name || !ALLOWED_ROLES.has(session.user.role.name)) {
+    return null;
+  }
+
+  return session;
+}
+
+export async function GET() {
+  const session = await ensureAdmin();
+
+  if (!session) {
+    return NextResponse.json({ error: 'Доступ запрещён' }, { status: 403 });
+  }
+
+  try {
+    const snapshot = await getDesignSystemSettings();
+
+    return NextResponse.json({ data: snapshot.settings, updatedAt: snapshot.updatedAt });
+  } catch (error) {
+    console.error('[API] Ошибка загрузки настроек дизайн-системы', error);
+    return NextResponse.json(
+      { error: 'Не удалось загрузить настройки дизайн-системы' },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PUT(request: Request) {
+  const session = await ensureAdmin();
+
+  if (!session) {
+    return NextResponse.json({ error: 'Доступ запрещён' }, { status: 403 });
+  }
+
+  try {
+    const payload = await request.json();
+    const parsed = validateDesignSystemPayload(payload);
+    const snapshot = await saveDesignSystemSettings(parsed);
+
+    return NextResponse.json({
+      message: 'Дизайн-система успешно обновлена',
+      data: snapshot.settings,
+      updatedAt: snapshot.updatedAt,
+    });
+  } catch (error) {
+    console.error('[API] Ошибка сохранения дизайн-системы', error);
+
+    if (error instanceof SyntaxError) {
+      return NextResponse.json({ error: 'Некорректный формат запроса' }, { status: 400 });
+    }
+
+    if (error instanceof ZodError) {
+      return NextResponse.json(
+        { error: 'Проверьте заполненные поля', details: error.issues },
+        { status: 422 },
+      );
+    }
+
+    return NextResponse.json(
+      { error: 'Не удалось сохранить настройки дизайн-системы' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/fonts.ts
+++ b/src/app/fonts.ts
@@ -1,29 +1,29 @@
 // Местоположение: src/app/fonts.ts
 
-// 1. Импортируем все три нужных нам шрифты из библиотеки Google Fonts.
-import { Unbounded, Manrope, PT_Mono } from 'next/font/google';
+// 1. Импортируем актуальные шрифты из библиотеки Google Fonts.
+import { Manrope, PT_Mono } from 'next/font/google';
 
-// 2. Настраиваем шрифт для ЗАГОЛОВКОВ (Unbounded).
-export const fontHeading = Unbounded({
+// 2. Заголовки используют Manrope с переменной --font-heading.
+export const fontHeading = Manrope({
   subsets: ['cyrillic', 'latin'],
   display: 'swap',
-  variable: '--font-heading', // Переменная для заголовков
-  weight: 'variable',
+  variable: '--font-heading',
+  weight: ['400', '500', '600', '700', '800'],
 });
 
-// 3. Настраиваем шрифт для ОСНОВНОГО ТЕКСТА (Manrope).
+// 3. Основной текст также использует Manrope, но со своей переменной.
 export const fontBody = Manrope({
   subsets: ['cyrillic', 'latin'],
   display: 'swap',
-  variable: '--font-body', // Переменная для основного текста
-  weight: ['200', '300', '400', '500', '600', '700', '800'], 
+  variable: '--font-body',
+  weight: ['300', '400', '500', '600', '700'],
 });
 
-// 4. НОВЫЙ ШРИФТ! Настраиваем шрифт для АКЦЕНТНОГО/МОНОШИРИННОГО ТЕКСТА (PT Mono).
+// 4. Акцентный / моноширинный шрифт — PT Mono.
 export const fontMono = PT_Mono({
   subsets: ['cyrillic', 'latin'],
   display: 'swap',
   variable: '--font-mono', // Переменная для ацентного/моношириного
   // У PT Mono только одно стандартное начертание, поэтому указываем '400' (Regular).
-  weight: '400', 
+  weight: '400',
 });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,12 +13,12 @@
 /* --- ШАГ 2: ОПРЕДЕЛЕНИЕ БАЗОВОГО СЛОЯ --- */
 @layer base {
   :root {
-    --background-primary: #FFFFFF;
-    --text-primary: #272727;
-    --brand-lilac-color: #6B80C5;
-    --brand-lilac-light-color: #C1D0FF;
-    --heart-red: #D32F2F;
-    --feedback-error-color: #E06F6F;
+    --background-primary: var(--ds-color-background, #FFFFFF);
+    --text-primary: var(--ds-color-text-primary, #272727);
+    --brand-lilac-color: var(--ds-color-primary, #6B80C5);
+    --brand-lilac-light-color: var(--ds-color-accent, #C1D0FF);
+    --heart-red: var(--ds-color-danger, #D32F2F);
+    --feedback-error-color: var(--ds-color-danger, #E06F6F);
     --mobile-footer-height: 0px;
   }
 
@@ -31,7 +31,7 @@
     -webkit-font-smoothing: antialiased;
     background-color: var(--background-primary);
     color: var(--text-primary);
-    font-family: var(--font-body);
+    font-family: var(--ds-font-body, var(--font-body));
     overscroll-behavior-y: contain;
 
     padding-left: env(safe-area-inset-left);
@@ -48,7 +48,7 @@
   }
 
   h1, h2, h3, h4, h5, h6 {
-    font-family: var(--font-heading);
+    font-family: var(--ds-font-heading, var(--font-heading));
     word-break: break-word;
     hyphens: auto;
   }
@@ -58,23 +58,24 @@
   }
 
   h1 {
-    font-size: clamp(2rem, 6vw + 1rem, 6rem);
-    line-height: 1.1;
-    letter-spacing: -0.03em;
-    font-weight: 900;
+    font-size: var(--ds-heading-1-size);
+    line-height: var(--ds-heading-1-line-height);
+    letter-spacing: var(--ds-heading-1-letter-spacing, -0.03em);
+    font-weight: var(--ds-heading-1-weight);
   }
 
   h2 {
-    font-size: clamp(1.75rem, 4vw + 0.5rem, 3.75rem);
-    line-height: 1.2;
-    letter-spacing: -0.02em;
-    font-weight: 800;
+    font-size: var(--ds-heading-2-size);
+    line-height: var(--ds-heading-2-line-height);
+    letter-spacing: var(--ds-heading-2-letter-spacing, -0.02em);
+    font-weight: var(--ds-heading-2-weight);
   }
 
   h3 {
-    font-size: clamp(1.3rem, 3vw + 0.5rem, 2.5rem);
-    line-height: 1.2;
-    font-weight: 700;
+    font-size: var(--ds-heading-3-size);
+    line-height: var(--ds-heading-3-line-height);
+    letter-spacing: var(--ds-heading-3-letter-spacing, 0em);
+    font-weight: var(--ds-heading-3-weight);
   }
 
   h4, h5, h6 {
@@ -82,17 +83,25 @@
   }
 
   p, button {
-    font-size: clamp(1rem, 0.8vw + 0.5rem, 1.125rem);
+    font-size: var(--ds-body-font-size);
   }
 
   p {
-    line-height: 1.6;
-    font-weight: 400;
+    line-height: var(--ds-body-line-height);
+    font-weight: var(--ds-body-font-weight);
+    letter-spacing: var(--ds-body-letter-spacing, 0);
   }
-  
+
   button {
     line-height: 1;
     font-weight: 700;
+  }
+
+  small {
+    font-size: var(--ds-small-font-size);
+    line-height: var(--ds-small-line-height);
+    font-weight: var(--ds-small-font-weight);
+    letter-spacing: var(--ds-small-letter-spacing, 0);
   }
 }
 

--- a/src/components/ClientInteractivity.tsx
+++ b/src/components/ClientInteractivity.tsx
@@ -38,6 +38,44 @@ export default function ClientInteractivity() {
     };
   }, [isMenuOpen]);
 
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const url = new URL(window.location.href);
+    const currentState = url.searchParams.get('menu');
+
+    if (isMenuOpen && currentState !== 'open') {
+      url.searchParams.set('menu', 'open');
+      window.history.replaceState(
+        window.history.state,
+        '',
+        `${url.pathname}${url.search}${url.hash}`,
+      );
+    }
+
+    if (!isMenuOpen && currentState === 'open') {
+      url.searchParams.delete('menu');
+      window.history.replaceState(
+        window.history.state,
+        '',
+        `${url.pathname}${url.search}${url.hash}`,
+      );
+    }
+  }, [isMenuOpen]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const url = new URL(window.location.href);
+    if (url.searchParams.get('menu') === 'open') {
+      setMenuOpen(true);
+    }
+  }, [setMenuOpen]);
+
   // --- НАЧАЛО ИЗМЕНЕНИЙ ---
   // Простая функция-переключатель
   const toggleMenu = () => {

--- a/src/components/FloatingMenuOverlay/AuthenticatedView.tsx
+++ b/src/components/FloatingMenuOverlay/AuthenticatedView.tsx
@@ -123,7 +123,7 @@ const AuthenticatedView = ({
         </Link>
         {user?.role?.name === 'ADMIN' && (
           <Link
-            href="https://admin.kyanchir.ru/dashboard"
+            href="https://admin.kyanchir.ru/"
             onClick={onClose}
             aria-label="Админ-панель"
             className="p-2"

--- a/src/components/admin/AdminPathNormalizer.tsx
+++ b/src/components/admin/AdminPathNormalizer.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+
+const ADMIN_PREFIX = '/admin';
+
+function normalizePath(pathname: string) {
+  if (!pathname.startsWith(ADMIN_PREFIX)) {
+    return null;
+  }
+
+  const normalized = pathname.slice(ADMIN_PREFIX.length) || '/';
+  return normalized.startsWith('/') ? normalized : `/${normalized}`;
+}
+
+export default function AdminPathNormalizer() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const normalized = pathname ? normalizePath(pathname) : null;
+
+    if (!normalized) {
+      return;
+    }
+
+    const { search, hash } = window.location;
+    const target = `${normalized}${search}${hash}`;
+
+    if (window.location.pathname !== normalized) {
+      window.history.replaceState(window.history.state, '', target);
+    }
+  }, [pathname]);
+
+  return null;
+}

--- a/src/components/admin/settings/DesignSystemForm.tsx
+++ b/src/components/admin/settings/DesignSystemForm.tsx
@@ -1,0 +1,880 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { CSSProperties } from 'react';
+import { toast } from 'react-hot-toast';
+import { LoadingButton } from '@/components/shared/ui';
+import { cn } from '@/lib/utils';
+import type {
+  DesignSystemSettings,
+  FontLibraryEntry,
+  SpacingTokenKey,
+  TypographyTokenKey,
+} from '@/lib/settings/design-system.shared';
+import {
+  buildDesignSystemVariableMap,
+  buildFontStack,
+  colorFieldMeta,
+  colorSections,
+  defaultFallbacksFor,
+  fontCategoryOptions,
+  pxToRem,
+  slugifyFontId,
+  spacingLabels,
+  spacingOrder,
+  typographyLabels,
+  typographyOrder,
+} from '@/lib/settings/design-system.shared';
+
+interface IconCatalogEntry {
+  name: string;
+  svg: string;
+}
+
+interface DesignSystemFormProps {
+  initialSettings: DesignSystemSettings;
+  defaultSettings: DesignSystemSettings;
+  icons: IconCatalogEntry[];
+}
+
+const weightOptions = [100, 200, 300, 400, 500, 600, 700, 800, 900];
+
+const defaultPreviewText = 'Съешь ещё этих мягких французских булок';
+
+function cloneSettings(settings: DesignSystemSettings) {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(settings);
+  }
+
+  return JSON.parse(JSON.stringify(settings)) as DesignSystemSettings;
+}
+
+function parseGoogleFontsFamily(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    const families = parsed.searchParams.getAll('family');
+    if (families.length === 0) {
+      return null;
+    }
+
+    const primary = families[0]?.split(':')[0];
+    if (!primary) {
+      return null;
+    }
+
+    return primary.replace(/\+/g, ' ');
+  } catch (error) {
+    console.warn('[DesignSystem] Не удалось распарсить ссылку Google Fonts', error);
+    return null;
+  }
+}
+
+function asCssFamily(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return 'sans-serif';
+  }
+
+  return /\s/.test(trimmed) ? `"${trimmed}"` : trimmed;
+}
+
+function useDesignSystemState(initial: DesignSystemSettings) {
+  const [settings, setSettings] = useState<DesignSystemSettings>(cloneSettings(initial));
+  const [snapshot, setSnapshot] = useState<DesignSystemSettings>(cloneSettings(initial));
+
+  useEffect(() => {
+    setSettings(cloneSettings(initial));
+    setSnapshot(cloneSettings(initial));
+  }, [initial]);
+
+  const isDirty = useMemo(
+    () => JSON.stringify(settings) !== JSON.stringify(snapshot),
+    [settings, snapshot],
+  );
+
+  return {
+    settings,
+    setSettings,
+    snapshot,
+    setSnapshot,
+    isDirty,
+  } as const;
+}
+
+export default function DesignSystemForm({
+  initialSettings,
+  defaultSettings,
+  icons,
+}: DesignSystemFormProps) {
+  const { settings, setSettings, snapshot, setSnapshot, isDirty } =
+    useDesignSystemState(initialSettings);
+  const [isSaving, setIsSaving] = useState(false);
+  const [newFontName, setNewFontName] = useState('');
+  const [newFontUrl, setNewFontUrl] = useState('');
+  const [newFontCategory, setNewFontCategory] = useState(fontCategoryOptions[0]?.value ?? 'sans-serif');
+  const [newFontPreview, setNewFontPreview] = useState(defaultPreviewText);
+
+  const designSystemStyle = useMemo(() => {
+    const map = buildDesignSystemVariableMap(settings);
+    return Object.entries(map).reduce((acc, [key, value]) => {
+      (acc as Record<string, string>)[key] = value;
+      return acc;
+    }, {} as CSSProperties);
+  }, [settings]);
+
+  const fontOptions = useMemo(
+    () =>
+      settings.fontLibrary.map((font) => ({
+        value: font.id,
+        label: font.name,
+      })),
+    [settings.fontLibrary],
+  );
+
+  const handleSiteNameChange = useCallback((value: string) => {
+    setSettings((prev) => ({ ...prev, siteName: value }));
+  }, []);
+
+  const handleColorChange = useCallback(
+    (key: keyof DesignSystemSettings['colors'], value: string) => {
+      const formatted = value.startsWith('#') ? value.toUpperCase() : `#${value.toUpperCase()}`;
+      setSettings((prev) => ({
+        ...prev,
+        colors: { ...prev.colors, [key]: formatted.slice(0, 9) },
+      }));
+    },
+    [],
+  );
+
+  const handleSpacingChange = useCallback((key: SpacingTokenKey, value: number) => {
+    if (Number.isNaN(value)) return;
+    setSettings((prev) => ({
+      ...prev,
+      spacing: { ...prev.spacing, [key]: Math.max(0, Math.round(value)) },
+    }));
+  }, []);
+
+  const handleTypographyChange = useCallback(
+    (
+      token: TypographyTokenKey,
+      field: keyof DesignSystemSettings['typography'][TypographyTokenKey],
+      value: number,
+    ) => {
+      if (Number.isNaN(value)) return;
+      setSettings((prev) => ({
+        ...prev,
+        typography: {
+          ...prev.typography,
+          [token]: {
+            ...prev.typography[token],
+            [field]:
+              field === 'letterSpacing'
+                ? Number(value.toFixed(2))
+                : field === 'lineHeight'
+                  ? Number(value.toFixed(2))
+                  : Math.round(value),
+          },
+        },
+      }));
+    },
+    [],
+  );
+
+  const handleTypographyLetterSpacing = useCallback(
+    (token: TypographyTokenKey, value: number) => {
+      if (Number.isNaN(value)) return;
+      setSettings((prev) => ({
+        ...prev,
+        typography: {
+          ...prev.typography,
+          [token]: {
+            ...prev.typography[token],
+            letterSpacing: Number(value.toFixed(3)),
+          },
+        },
+      }));
+    },
+    [],
+  );
+
+  const handleFontAssignment = useCallback(
+    (role: keyof DesignSystemSettings['fonts'], id: string) => {
+      setSettings((prev) => ({
+        ...prev,
+        fonts: {
+          ...prev.fonts,
+          [role]: id,
+        },
+      }));
+    },
+    [],
+  );
+
+  const handleFontMetadataChange = useCallback(
+    (id: string, field: keyof FontLibraryEntry, value: string) => {
+      setSettings((prev) => ({
+        ...prev,
+        fontLibrary: prev.fontLibrary.map((font) =>
+          font.id === id
+            ? {
+                ...font,
+                [field]:
+                  field === 'fallbacks'
+                    ? value.split(',').map((item) => item.trim()).filter(Boolean)
+                    : value.trim(),
+              }
+            : font,
+        ),
+      }));
+    },
+    [],
+  );
+
+  const handleFontPreviewChange = useCallback(
+    (id: string, preview: string) => {
+      setSettings((prev) => ({
+        ...prev,
+        fontLibrary: prev.fontLibrary.map((font) =>
+          font.id === id
+            ? {
+                ...font,
+                previewText: preview,
+              }
+            : font,
+        ),
+      }));
+    },
+    [],
+  );
+
+  const handleRemoveFont = useCallback((id: string) => {
+    setSettings((prev) => {
+      const nextLibrary = prev.fontLibrary.filter((font) => font.id !== id);
+      const ensureAssignment = (current: string, fallback: keyof DesignSystemSettings['fonts']) => {
+        if (nextLibrary.some((font) => font.id === current)) {
+          return current;
+        }
+        return defaultSettings.fonts[fallback];
+      };
+
+      return {
+        ...prev,
+        fontLibrary: nextLibrary,
+        fonts: {
+          heading: ensureAssignment(prev.fonts.heading, 'heading'),
+          body: ensureAssignment(prev.fonts.body, 'body'),
+          accent: ensureAssignment(prev.fonts.accent, 'accent'),
+        },
+      };
+    });
+  }, [defaultSettings.fonts]);
+
+  const handleAddFont = useCallback(
+    (event: React.FormEvent) => {
+      event.preventDefault();
+
+      const familyFromUrl = parseGoogleFontsFamily(newFontUrl);
+      const familyName = (newFontName || familyFromUrl)?.trim();
+
+      if (!familyName) {
+        toast.error('Укажите название шрифта или корректную ссылку Google Fonts');
+        return;
+      }
+
+      const id = slugifyFontId(familyName);
+      if (!id) {
+        toast.error('Не удалось сформировать идентификатор шрифта');
+        return;
+      }
+
+      const cssFamily = asCssFamily(familyFromUrl ?? familyName);
+      const fallbacks = defaultFallbacksFor(newFontCategory);
+
+      const entry: FontLibraryEntry = {
+        id,
+        name: familyName,
+        family: cssFamily,
+        cssUrl: newFontUrl || undefined,
+        fallbacks,
+        category: newFontCategory,
+        previewText: newFontPreview || defaultPreviewText,
+      };
+
+      setSettings((prev) => {
+        const exists = prev.fontLibrary.some((font) => font.id === id);
+        const fontLibrary = exists
+          ? prev.fontLibrary.map((font) => (font.id === id ? { ...font, ...entry } : font))
+          : [...prev.fontLibrary, entry];
+
+        return {
+          ...prev,
+          fontLibrary,
+        };
+      });
+
+      toast.success('Шрифт добавлен в библиотеку');
+      setNewFontName('');
+      setNewFontUrl('');
+      setNewFontCategory(fontCategoryOptions[0]?.value ?? 'sans-serif');
+      setNewFontPreview(defaultPreviewText);
+    },
+    [newFontCategory, newFontName, newFontPreview, newFontUrl],
+  );
+
+  const handleResetToDefaults = useCallback(() => {
+    setSettings(cloneSettings(defaultSettings));
+  }, [defaultSettings]);
+
+  const handleRevert = useCallback(() => {
+    setSettings(cloneSettings(snapshot));
+  }, [snapshot]);
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      setIsSaving(true);
+
+      try {
+        const response = await fetch('/api/admin/settings/design-system', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(settings),
+        });
+
+        const data = await response.json();
+
+        if (!response.ok) {
+          throw new Error(data?.error ?? 'Не удалось сохранить дизайн-систему');
+        }
+
+        if (!data?.data) {
+          throw new Error('Сервер не вернул данные дизайн-системы');
+        }
+
+        const nextSettings = cloneSettings(data.data as DesignSystemSettings);
+        setSettings(nextSettings);
+        setSnapshot(nextSettings);
+        toast.success('Дизайн-система обновлена');
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Неизвестная ошибка сохранения';
+        toast.error(message);
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [settings, setSnapshot],
+  );
+
+  const handleCopyIconMarkup = useCallback(async (svg: string) => {
+    try {
+      await navigator.clipboard.writeText(svg);
+      toast.success('SVG скопирован в буфер обмена');
+    } catch (error) {
+      console.error('[DesignSystem] Не удалось скопировать SVG', error);
+      toast.error('Не удалось скопировать SVG');
+    }
+  }, []);
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-10">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900">Управление дизайн-системой</h2>
+          <p className="text-sm text-gray-600">
+            Здесь собраны все ключевые токены: цвета, типографика, отступы, шрифты и иконки.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            onClick={handleResetToDefaults}
+            className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:border-gray-400 hover:text-gray-900"
+          >
+            Сбросить к дефолту
+          </button>
+          <button
+            type="button"
+            onClick={handleRevert}
+            disabled={!isDirty}
+            className={cn(
+              'rounded-md border border-gray-300 px-4 py-2 text-sm font-medium transition',
+              isDirty
+                ? 'text-gray-700 hover:border-gray-400 hover:text-gray-900'
+                : 'cursor-not-allowed text-gray-400',
+            )}
+          >
+            Отменить изменения
+          </button>
+          <LoadingButton
+            type="submit"
+            isLoading={isSaving}
+            disabled={!isDirty}
+            className={cn(
+              'bg-gray-900 text-white hover:bg-gray-800',
+              !isDirty && !isSaving && 'cursor-not-allowed opacity-60',
+            )}
+          >
+            Сохранить
+          </LoadingButton>
+        </div>
+      </div>
+
+      <section className="grid gap-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <h3 className="text-lg font-semibold text-gray-900">Идентика проекта</h3>
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="flex flex-col space-y-1">
+            <span className="text-sm font-medium text-gray-700">Название сайта</span>
+            <input
+              type="text"
+              value={settings.siteName}
+              onChange={(event) => handleSiteNameChange(event.target.value)}
+              placeholder="Например: Kyanchir"
+              className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300"
+              maxLength={60}
+            />
+            <span className="text-xs text-gray-500">Используется в мета-тегах и шапке сайта</span>
+          </label>
+        </div>
+      </section>
+
+      <section className="grid gap-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900">Цветовая палитра</h3>
+          <p className="mt-1 text-sm text-gray-600">
+            Задайте цвета бренда, фонов, текста и сервисных состояний. Все значения сохраняются в HEX.
+          </p>
+        </div>
+        <div className="grid gap-6 lg:grid-cols-2">
+          {colorSections.map((section) => (
+            <div key={section.title} className="space-y-4 rounded-md border border-gray-100 bg-gray-50 p-4">
+              <p className="text-sm font-semibold text-gray-900">{section.title}</p>
+              <div className="grid gap-4">
+                {section.keys.map((key) => (
+                  <div key={key} className="flex flex-col gap-2">
+                    <div className="flex items-center justify-between gap-3">
+                      <label className="text-sm font-medium text-gray-700">
+                        {colorFieldMeta[key].label}
+                      </label>
+                      <input
+                        type="color"
+                        value={settings.colors[key]}
+                        onChange={(event) => handleColorChange(key, event.target.value)}
+                        className="h-9 w-12 cursor-pointer rounded border border-gray-200"
+                        aria-label={`Выбор цвета ${colorFieldMeta[key].label}`}
+                      />
+                    </div>
+                    <input
+                      type="text"
+                      value={settings.colors[key]}
+                      onChange={(event) => handleColorChange(key, event.target.value)}
+                      className="rounded-md border border-gray-300 px-3 py-2 text-sm uppercase focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300"
+                    />
+                    <div
+                      className="h-10 rounded-md border border-gray-200"
+                      style={{ backgroundColor: settings.colors[key] }}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="grid gap-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <div className="space-y-3">
+          <h3 className="text-lg font-semibold text-gray-900">Библиотека шрифтов</h3>
+          <p className="text-sm text-gray-600">
+            Добавляйте шрифты через ссылки Google Fonts: мы автоматически определим семейство и подключим его к
+            проекту. Затем выберите, какой шрифт использовать для заголовков, текста и акцентных элементов.
+          </p>
+          <form onSubmit={handleAddFont} className="grid gap-4 rounded-md border border-dashed border-gray-300 bg-gray-50 p-4 md:grid-cols-2">
+            <div className="space-y-1">
+              <label className="text-xs font-medium text-gray-600">Название шрифта</label>
+              <input
+                value={newFontName}
+                onChange={(event) => setNewFontName(event.target.value)}
+                placeholder="Например, Space Grotesk"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300"
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs font-medium text-gray-600">Ссылка на Google Fonts</label>
+              <input
+                value={newFontUrl}
+                onChange={(event) => setNewFontUrl(event.target.value)}
+                placeholder="https://fonts.googleapis.com/css2?family=..."
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300"
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs font-medium text-gray-600">Категория</label>
+              <select
+                value={newFontCategory}
+                onChange={(event) => setNewFontCategory(event.target.value as FontLibraryEntry['category'])}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300"
+              >
+                {fontCategoryOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs font-medium text-gray-600">Текст для предпросмотра</label>
+              <input
+                value={newFontPreview}
+                onChange={(event) => setNewFontPreview(event.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300"
+              />
+            </div>
+            <div className="md:col-span-2">
+              <button
+                type="submit"
+                className="rounded-md bg-gray-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-gray-800"
+              >
+                Добавить шрифт
+              </button>
+            </div>
+          </form>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          {settings.fontLibrary.map((font) => (
+            <div key={font.id} className="flex flex-col gap-3 rounded-md border border-gray-200 bg-white p-4 shadow-sm">
+              <div className="flex items-start justify-between gap-3">
+                <div className="space-y-1">
+                  <label className="text-xs font-medium text-gray-500">Отображаемое имя</label>
+                  <input
+                    value={font.name}
+                    onChange={(event) => handleFontMetadataChange(font.id, 'name', event.target.value)}
+                    className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300"
+                  />
+                </div>
+                {!font.isSystem && (
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveFont(font.id)}
+                    className="text-xs font-semibold text-red-500 transition hover:text-red-600"
+                  >
+                    Удалить
+                  </button>
+                )}
+              </div>
+              <div className="grid gap-2">
+                <label className="text-xs font-medium text-gray-500">CSS family</label>
+                <input
+                  value={font.family}
+                  onChange={(event) => handleFontMetadataChange(font.id, 'family', event.target.value)}
+                  className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300"
+                />
+              </div>
+              <div className="grid gap-2">
+                <label className="text-xs font-medium text-gray-500">Fallback (через запятую)</label>
+                <input
+                  value={font.fallbacks.join(', ')}
+                  onChange={(event) => handleFontMetadataChange(font.id, 'fallbacks', event.target.value)}
+                  className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300"
+                />
+              </div>
+              {font.cssUrl && (
+                <a
+                  href={font.cssUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-xs text-gray-500 underline hover:text-gray-700"
+                >
+                  Открыть источник Google Fonts
+                </a>
+              )}
+              <div className="rounded-md border border-dashed border-gray-300 bg-gray-50 p-3">
+                <p className="text-xs font-medium text-gray-500">Превью</p>
+                <p style={{ fontFamily: buildFontStack(font) }} className="mt-2 text-base text-gray-900">
+                  {font.previewText || defaultPreviewText}
+                </p>
+                <textarea
+                  value={font.previewText ?? ''}
+                  onChange={(event) => handleFontPreviewChange(font.id, event.target.value)}
+                  className="mt-3 w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300"
+                  rows={2}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="grid gap-4 rounded-md border border-gray-100 bg-gray-50 p-4 md:grid-cols-3">
+          <div className="space-y-2">
+            <p className="text-sm font-semibold text-gray-900">Назначение шрифтов</p>
+            <p className="text-xs text-gray-600">
+              Выберите, какие шрифты из библиотеки будут использоваться для разных ролей.
+            </p>
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-gray-600">Заголовки</label>
+            <select
+              value={settings.fonts.heading}
+              onChange={(event) => handleFontAssignment('heading', event.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300"
+            >
+              {fontOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-gray-600">Основной текст</label>
+            <select
+              value={settings.fonts.body}
+              onChange={(event) => handleFontAssignment('body', event.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300"
+            >
+              {fontOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-gray-600">Акцент / моно</label>
+            <select
+              value={settings.fonts.accent}
+              onChange={(event) => handleFontAssignment('accent', event.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300"
+            >
+              {fontOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900">Типографика</h3>
+          <p className="mt-1 text-sm text-gray-600">
+            Укажите размеры для мобильного и десктопа, line-height и насыщенность. Мы автоматически построим fluid-типографику.
+          </p>
+        </div>
+        <div className="grid gap-4">
+          {typographyOrder.map((tokenKey) => {
+            const token = settings.typography[tokenKey];
+            return (
+              <div key={tokenKey} className="grid gap-3 rounded-md border border-gray-100 bg-gray-50 p-4 md:grid-cols-4">
+                <div className="space-y-2">
+                  <p className="text-sm font-semibold text-gray-900">{typographyLabels[tokenKey].label}</p>
+                  <p className="text-xs text-gray-500">{typographyLabels[tokenKey].sample}</p>
+                </div>
+                <div className="space-y-1">
+                  <label className="text-xs font-medium text-gray-600">Мобильный (px)</label>
+                  <input
+                    type="number"
+                    value={token.mobile}
+                    min={10}
+                    max={160}
+                    onChange={(event) =>
+                      handleTypographyChange(tokenKey, 'mobile', Number(event.target.value))
+                    }
+                    className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <label className="text-xs font-medium text-gray-600">Десктоп (px)</label>
+                  <input
+                    type="number"
+                    value={token.desktop}
+                    min={12}
+                    max={200}
+                    onChange={(event) =>
+                      handleTypographyChange(tokenKey, 'desktop', Number(event.target.value))
+                    }
+                    className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300"
+                  />
+                </div>
+                <div className="grid gap-3 md:grid-cols-2">
+                  <div className="space-y-1">
+                    <label className="text-xs font-medium text-gray-600">Line-height</label>
+                    <input
+                      type="number"
+                      step={0.05}
+                      value={token.lineHeight}
+                      min={1}
+                      max={2.6}
+                      onChange={(event) =>
+                        handleTypographyChange(tokenKey, 'lineHeight', Number(event.target.value))
+                      }
+                      className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300"
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <label className="text-xs font-medium text-gray-600">Насыщенность</label>
+                    <select
+                      value={token.weight}
+                      onChange={(event) =>
+                        handleTypographyChange(tokenKey, 'weight', Number(event.target.value))
+                      }
+                      className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300"
+                    >
+                      {weightOptions.map((weight) => (
+                        <option key={weight} value={weight}>
+                          {weight}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="space-y-1 md:col-span-2">
+                    <label className="text-xs font-medium text-gray-600">Letter-spacing (em)</label>
+                    <input
+                      type="number"
+                      step={0.01}
+                      value={token.letterSpacing ?? 0}
+                      min={-0.4}
+                      max={0.4}
+                      onChange={(event) =>
+                        handleTypographyLetterSpacing(tokenKey, Number(event.target.value))
+                      }
+                      className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300"
+                    />
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="grid gap-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900">Шкала отступов</h3>
+          <p className="mt-1 text-sm text-gray-600">
+            Значения задаются в пикселях и автоматически конвертируются в rem для CSS-переменных и Tailwind.
+          </p>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-4">
+            {spacingOrder.map((spacingKey) => (
+              <label key={spacingKey} className="flex items-center justify-between gap-4">
+                <div>
+                  <span className="block text-sm font-medium text-gray-700">
+                    {spacingLabels[spacingKey].label}
+                  </span>
+                  <span className="block text-xs text-gray-500">{spacingLabels[spacingKey].hint}</span>
+                </div>
+                <input
+                  type="number"
+                  value={settings.spacing[spacingKey]}
+                  min={0}
+                  max={400}
+                  onChange={(event) => handleSpacingChange(spacingKey, Number(event.target.value))}
+                  className="w-24 rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300"
+                />
+              </label>
+            ))}
+          </div>
+          <div className="space-y-3 rounded-md border border-gray-100 bg-gray-50 p-4">
+            <p className="text-sm font-semibold text-gray-900">Визуальная шкала (rem)</p>
+            <div className="space-y-3">
+              {spacingOrder.map((spacingKey) => (
+                <div key={spacingKey} className="flex items-center gap-3">
+                  <span className="w-10 text-xs font-medium text-gray-500">
+                    {spacingLabels[spacingKey].label}
+                  </span>
+                  <div
+                    className="h-2 rounded bg-gray-300"
+                    style={{ width: `calc(${pxToRem(settings.spacing[spacingKey])} * 12)` }}
+                  />
+                  <span className="text-xs text-gray-500">{settings.spacing[spacingKey]}px</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <h3 className="text-lg font-semibold text-gray-900">Предпросмотр дизайн-системы</h3>
+        <p className="mt-1 text-sm text-gray-600">
+          Используем актуальные токены, чтобы показать, как они повлияют на интерфейс.
+        </p>
+        <div style={designSystemStyle} className="mt-6 space-y-6 rounded-md border border-gray-100 bg-gray-50 p-6">
+          <div className="space-y-2">
+            <h1>Kyanchir Design Tokens</h1>
+            <h2>Гибкая система, управляемая из админки</h2>
+            <h3>Предпросмотр заголовка третьего уровня</h3>
+            <p>
+              Это пример абзаца, который использует переменные дизайн-системы. Измените значения слева и сразу увидите
+              результат.
+            </p>
+            <small>Мелкий текст для подписей и вспомогательной информации.</small>
+          </div>
+          <div className="space-y-4">
+            <p className="text-sm font-semibold text-gray-700">Цветовая палитра</p>
+            <div className="grid gap-3 md:grid-cols-3">
+              {Object.entries(settings.colors).map(([key, value]) => (
+                <div key={key} className="flex items-center gap-3 rounded-md border border-gray-200 bg-white p-3">
+                  <span className="h-10 w-10 rounded-md border border-gray-100" style={{ backgroundColor: value }} />
+                  <div>
+                    <p className="text-xs font-semibold text-gray-700">{colorFieldMeta[key as keyof typeof colorFieldMeta].label}</p>
+                    <p className="text-xs text-gray-500">{value}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="space-y-4">
+            <p className="text-sm font-semibold text-gray-700">Шкала отступов</p>
+            <div className="flex flex-wrap gap-ds-sm rounded-md border border-dashed border-gray-300 p-ds-md">
+              {spacingOrder.map((spacingKey) => (
+                <div
+                  key={spacingKey}
+                  className="flex h-10 w-24 items-center justify-center rounded-md bg-white text-xs text-gray-600 shadow-sm"
+                >
+                  {spacingLabels[spacingKey].label}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <h3 className="text-lg font-semibold text-gray-900">Каталог иконок</h3>
+        <p className="mt-1 text-sm text-gray-600">
+          Все SVG, используемые на сайте. Можно скопировать код и при необходимости заменить иконку через админку в будущем.
+        </p>
+        <div className="mt-6 grid gap-4 md:grid-cols-3 xl:grid-cols-4">
+          {icons.map((icon) => (
+            <div key={icon.name} className="flex flex-col gap-3 rounded-md border border-gray-200 bg-gray-50 p-4">
+              <div className="flex items-center justify-between gap-3">
+                <p className="text-sm font-semibold text-gray-900">{icon.name}</p>
+                <button
+                  type="button"
+                  onClick={() => handleCopyIconMarkup(icon.svg)}
+                  className="text-xs font-semibold text-gray-500 transition hover:text-gray-700"
+                >
+                  Скопировать SVG
+                </button>
+              </div>
+              <div
+                className="flex h-16 items-center justify-center rounded-md border border-dashed border-gray-300 bg-white"
+                dangerouslySetInnerHTML={{ __html: icon.svg }}
+              />
+              <textarea
+                value={icon.svg}
+                readOnly
+                className="h-28 w-full rounded-md border border-gray-300 px-3 py-2 text-xs font-mono text-gray-600 focus:outline-none"
+              />
+            </div>
+          ))}
+        </div>
+      </section>
+    </form>
+  );
+}

--- a/src/components/admin/users/UsersTable.tsx
+++ b/src/components/admin/users/UsersTable.tsx
@@ -72,14 +72,15 @@ export default function UsersTable({
   const [refreshKey, setRefreshKey] = useState(0);
 
   const debouncedSearch = useDebounce(search, 400, { maxWait: 1200 });
+  const handleRetryToast = useCallback((attempt: number) => {
+    toast.loading(`Повторная попытка загрузки (${attempt + 1})...`, {
+      id: 'users-retry',
+    });
+  }, []);
   const { execute } = useRetry({
     retries: 2,
     delay: 600,
-    onRetry: (attempt) => {
-      toast.loading(`Повторная попытка загрузки (${attempt + 1})...`, {
-        id: 'users-retry',
-      });
-    },
+    onRetry: handleRetryToast,
   });
 
   useEffect(() => {

--- a/src/lib/icons/catalog.ts
+++ b/src/lib/icons/catalog.ts
@@ -1,0 +1,31 @@
+import { createElement } from 'react';
+import type { SVGProps } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import * as sharedIcons from '@/components/shared/icons';
+
+export interface IconCatalogEntry {
+  name: string;
+  svg: string;
+}
+
+export function buildIconCatalog(): IconCatalogEntry[] {
+  return Object.entries(sharedIcons)
+    .filter((entry): entry is [string, (props: SVGProps<SVGSVGElement>) => JSX.Element] => {
+      const [, component] = entry;
+      return typeof component === 'function';
+    })
+    .map(([name, Icon]) => {
+      const svg = renderToStaticMarkup(
+        createElement(Icon, {
+          width: 32,
+          height: 32,
+          strokeWidth: 1.5,
+        }),
+      );
+      return {
+        name,
+        svg,
+      } satisfies IconCatalogEntry;
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/src/lib/settings/design-system.shared.ts
+++ b/src/lib/settings/design-system.shared.ts
@@ -1,0 +1,564 @@
+import { z } from 'zod';
+
+export type FontCategory =
+  | 'sans-serif'
+  | 'serif'
+  | 'monospace'
+  | 'display'
+  | 'handwriting';
+
+export interface FontLibraryEntry {
+  id: string;
+  name: string;
+  family: string;
+  cssUrl?: string;
+  fallbacks: string[];
+  category: FontCategory;
+  previewText?: string;
+  isSystem?: boolean;
+}
+
+export interface TypographyToken {
+  mobile: number;
+  desktop: number;
+  lineHeight: number;
+  weight: number;
+  letterSpacing?: number | null;
+}
+
+export type TypographyTokenKey = 'h1' | 'h2' | 'h3' | 'body' | 'small';
+
+export type SpacingTokenKey = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl';
+
+export interface DesignSystemColors {
+  primary: string;
+  primaryForeground: string;
+  accent: string;
+  accentForeground: string;
+  background: string;
+  surface: string;
+  surfaceForeground: string;
+  border: string;
+  neutral: string;
+  neutralForeground: string;
+  muted: string;
+  mutedForeground: string;
+  textPrimary: string;
+  textSecondary: string;
+  success: string;
+  warning: string;
+  danger: string;
+}
+
+export interface DesignSystemSettings {
+  siteName: string;
+  colors: DesignSystemColors;
+  fonts: {
+    heading: string;
+    body: string;
+    accent: string;
+  };
+  fontLibrary: FontLibraryEntry[];
+  typography: Record<TypographyTokenKey, TypographyToken>;
+  spacing: Record<SpacingTokenKey, number>;
+}
+
+const HEX_COLOR_REGEX = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+
+export const fontCategoryOptions: Array<{ value: FontCategory; label: string }> = [
+  { value: 'sans-serif', label: 'Sans-serif' },
+  { value: 'serif', label: 'Serif' },
+  { value: 'display', label: 'Display' },
+  { value: 'handwriting', label: 'Handwriting' },
+  { value: 'monospace', label: 'Monospace' },
+];
+
+export const colorFieldMeta: Record<keyof DesignSystemColors, { label: string; description?: string }> = {
+  primary: { label: 'Брендовый цвет' },
+  primaryForeground: { label: 'Текст на брендовых элементах' },
+  accent: { label: 'Акцентный цвет' },
+  accentForeground: { label: 'Текст на акцентах' },
+  background: { label: 'Основной фон' },
+  surface: { label: 'Поверхности / карточки' },
+  surfaceForeground: { label: 'Текст на поверхностях' },
+  border: { label: 'Границы и разделители' },
+  neutral: { label: 'Нейтральный' },
+  neutralForeground: { label: 'Текст на нейтральном фоне' },
+  muted: { label: 'Мутный / вторичный' },
+  mutedForeground: { label: 'Текст на мутном фоне' },
+  textPrimary: { label: 'Основной текст' },
+  textSecondary: { label: 'Вторичный текст' },
+  success: { label: 'Успех' },
+  warning: { label: 'Предупреждение' },
+  danger: { label: 'Ошибка' },
+};
+
+export const colorSections: Array<{ title: string; keys: Array<keyof DesignSystemColors> }> = [
+  { title: 'Бренд и акценты', keys: ['primary', 'primaryForeground', 'accent', 'accentForeground'] },
+  { title: 'Фоны и поверхности', keys: ['background', 'surface', 'surfaceForeground', 'border'] },
+  { title: 'Текст и нейтральные', keys: ['textPrimary', 'textSecondary', 'neutral', 'neutralForeground', 'muted', 'mutedForeground'] },
+  { title: 'Статусы', keys: ['success', 'warning', 'danger'] },
+];
+
+export const typographyLabels: Record<TypographyTokenKey, { label: string; sample: string }> = {
+  h1: { label: 'Заголовок H1', sample: 'Большой заголовок' },
+  h2: { label: 'Заголовок H2', sample: 'Средний заголовок' },
+  h3: { label: 'Заголовок H3', sample: 'Малый заголовок' },
+  body: { label: 'Основной текст', sample: 'Основной текстовый блок' },
+  small: { label: 'Подписи', sample: 'Подпись / пояснение' },
+};
+
+export const spacingLabels: Record<SpacingTokenKey, { label: string; hint: string }> = {
+  xs: { label: 'XS', hint: 'Минимальные отступы, 4px' },
+  sm: { label: 'SM', hint: 'Компактные отступы, 8px' },
+  md: { label: 'MD', hint: 'Базовые отступы, 16px' },
+  lg: { label: 'LG', hint: 'Крупные отступы, 24px' },
+  xl: { label: 'XL', hint: 'Секции, 32px' },
+  '2xl': { label: '2XL', hint: 'Крупные блоки, 48px' },
+  '3xl': { label: '3XL', hint: 'Герои, 64px' },
+};
+
+export const spacingOrder: SpacingTokenKey[] = ['xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl'];
+
+export const typographyOrder: TypographyTokenKey[] = ['h1', 'h2', 'h3', 'body', 'small'];
+
+const TYPOGRAPHY_VARIABLES: Record<
+  TypographyTokenKey,
+  { size: string; lineHeight: string; weight: string; letterSpacing: string }
+> = {
+  h1: {
+    size: '--ds-heading-1-size',
+    lineHeight: '--ds-heading-1-line-height',
+    weight: '--ds-heading-1-weight',
+    letterSpacing: '--ds-heading-1-letter-spacing',
+  },
+  h2: {
+    size: '--ds-heading-2-size',
+    lineHeight: '--ds-heading-2-line-height',
+    weight: '--ds-heading-2-weight',
+    letterSpacing: '--ds-heading-2-letter-spacing',
+  },
+  h3: {
+    size: '--ds-heading-3-size',
+    lineHeight: '--ds-heading-3-line-height',
+    weight: '--ds-heading-3-weight',
+    letterSpacing: '--ds-heading-3-letter-spacing',
+  },
+  body: {
+    size: '--ds-body-font-size',
+    lineHeight: '--ds-body-line-height',
+    weight: '--ds-body-font-weight',
+    letterSpacing: '--ds-body-letter-spacing',
+  },
+  small: {
+    size: '--ds-small-font-size',
+    lineHeight: '--ds-small-line-height',
+    weight: '--ds-small-font-weight',
+    letterSpacing: '--ds-small-letter-spacing',
+  },
+};
+
+const hexColor = z
+  .string()
+  .trim()
+  .toUpperCase()
+  .refine((value) => HEX_COLOR_REGEX.test(value), 'Используйте HEX-формат (#RRGGBB)');
+
+const fontLibraryEntrySchema = z.object({
+  id: z
+    .string()
+    .min(2, 'Минимум 2 символа')
+    .max(50, 'Максимум 50 символов')
+    .regex(/^[a-z0-9-]+$/i, 'Допустимы латинские буквы, цифры и дефис')
+    .transform((value) => value.toLowerCase()),
+  name: z
+    .string()
+    .min(2, 'Название слишком короткое')
+    .max(60, 'Название слишком длинное')
+    .transform((value) => value.trim()),
+  family: z
+    .string()
+    .min(1, 'Укажите CSS-имя семейства')
+    .max(120, 'Слишком длинное имя семейства')
+    .transform((value) => value.trim()),
+  cssUrl: z
+    .string()
+    .trim()
+    .url('Ссылка должна быть валидной')
+    .optional(),
+  fallbacks: z.array(
+    z
+      .string()
+      .min(1, 'Fallback не может быть пустым')
+      .max(60, 'Слишком длинное название fallback')
+      .transform((value) => value.trim()),
+  ),
+  category: z.custom<FontCategory>((value) =>
+    value === 'sans-serif' ||
+    value === 'serif' ||
+    value === 'monospace' ||
+    value === 'display' ||
+    value === 'handwriting',
+  ),
+  previewText: z
+    .string()
+    .max(120, 'Слишком длинный текст превью')
+    .optional(),
+  isSystem: z.boolean().optional(),
+});
+
+const typographyTokenSchema = z.object({
+  mobile: z
+    .number({ invalid_type_error: 'Значение должно быть числом' })
+    .min(10, 'Минимум 10px')
+    .max(120, 'Максимум 120px'),
+  desktop: z
+    .number({ invalid_type_error: 'Значение должно быть числом' })
+    .min(14, 'Минимум 14px')
+    .max(180, 'Максимум 180px'),
+  lineHeight: z
+    .number({ invalid_type_error: 'Значение должно быть числом' })
+    .min(1, 'Минимальное значение 1.0')
+    .max(2.6, 'Максимальное значение 2.6'),
+  weight: z
+    .number({ invalid_type_error: 'Используйте значение кратное 100' })
+    .int('Насыщенность должна быть целым числом')
+    .min(100, 'Минимум 100')
+    .max(900, 'Максимум 900'),
+  letterSpacing: z
+    .number({ invalid_type_error: 'Укажите число в em' })
+    .min(-0.4, 'Минимум -0.4em')
+    .max(0.4, 'Максимум 0.4em')
+    .nullable()
+    .optional(),
+});
+
+const typographySchema = z.object({
+  h1: typographyTokenSchema,
+  h2: typographyTokenSchema,
+  h3: typographyTokenSchema,
+  body: typographyTokenSchema,
+  small: typographyTokenSchema,
+});
+
+const spacingSchema = z.object({
+  xs: z.number({ invalid_type_error: 'Введите число в пикселях' }).min(0).max(96),
+  sm: z.number({ invalid_type_error: 'Введите число в пикселях' }).min(0).max(128),
+  md: z.number({ invalid_type_error: 'Введите число в пикселях' }).min(0).max(160),
+  lg: z.number({ invalid_type_error: 'Введите число в пикселях' }).min(0).max(200),
+  xl: z.number({ invalid_type_error: 'Введите число в пикселях' }).min(0).max(240),
+  '2xl': z.number({ invalid_type_error: 'Введите число в пикселях' }).min(0).max(320),
+  '3xl': z.number({ invalid_type_error: 'Введите число в пикселях' }).min(0).max(400),
+});
+
+const colorsSchema = z.object({
+  primary: hexColor,
+  primaryForeground: hexColor,
+  accent: hexColor,
+  accentForeground: hexColor,
+  background: hexColor,
+  surface: hexColor,
+  surfaceForeground: hexColor,
+  border: hexColor,
+  neutral: hexColor,
+  neutralForeground: hexColor,
+  muted: hexColor,
+  mutedForeground: hexColor,
+  textPrimary: hexColor,
+  textSecondary: hexColor,
+  success: hexColor,
+  warning: hexColor,
+  danger: hexColor,
+});
+
+export const designSystemSchema = z.object({
+  siteName: z
+    .string()
+    .min(2, 'Название слишком короткое')
+    .max(60, 'Название слишком длинное')
+    .transform((value) => value.trim()),
+  colors: colorsSchema,
+  fonts: z.object({
+    heading: z.string().min(1, 'Выберите шрифт для заголовков'),
+    body: z.string().min(1, 'Выберите шрифт для основного текста'),
+    accent: z.string().min(1, 'Выберите шрифт для акцентов'),
+  }),
+  fontLibrary: z
+    .array(fontLibraryEntrySchema)
+    .min(2, 'Добавьте минимум два шрифта'),
+  typography: typographySchema,
+  spacing: spacingSchema,
+});
+
+export const designSystemPartialSchema = designSystemSchema.deepPartial();
+
+export type DesignSystemPartial = z.infer<typeof designSystemPartialSchema>;
+
+export const DESIGN_SYSTEM_KEY = 'DESIGN_SYSTEM';
+
+const DEFAULT_FONT_LIBRARY: FontLibraryEntry[] = [
+  {
+    id: 'manrope',
+    name: 'Manrope',
+    family: '"Manrope"',
+    cssUrl:
+      'https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap',
+    fallbacks: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'sans-serif'],
+    category: 'sans-serif',
+    previewText: 'Съешь ещё этих мягких французских булок',
+    isSystem: true,
+  },
+  {
+    id: 'pt-mono',
+    name: 'PT Mono',
+    family: '"PT Mono"',
+    cssUrl: 'https://fonts.googleapis.com/css2?family=PT+Mono&display=swap',
+    fallbacks: ['monospace'],
+    category: 'monospace',
+    previewText: '0123456789 ABCDEF kyanchir.ru',
+    isSystem: true,
+  },
+];
+
+export const DEFAULT_DESIGN_SYSTEM_SETTINGS: DesignSystemSettings = {
+  siteName: 'Kyanchir',
+  colors: {
+    primary: '#6B80C5',
+    primaryForeground: '#FFFFFF',
+    accent: '#FBC0E3',
+    accentForeground: '#272727',
+    background: '#FFFFFF',
+    surface: '#F7F7FB',
+    surfaceForeground: '#272727',
+    border: '#E4E4EF',
+    neutral: '#3B3B45',
+    neutralForeground: '#FFFFFF',
+    muted: '#A1A1B3',
+    mutedForeground: '#FFFFFF',
+    textPrimary: '#272727',
+    textSecondary: '#6B80C5',
+    success: '#22C55E',
+    warning: '#F59E0B',
+    danger: '#EF4444',
+  },
+  fonts: {
+    heading: 'manrope',
+    body: 'manrope',
+    accent: 'pt-mono',
+  },
+  fontLibrary: DEFAULT_FONT_LIBRARY,
+  typography: {
+    h1: {
+      mobile: 40,
+      desktop: 96,
+      lineHeight: 1.1,
+      weight: 800,
+      letterSpacing: -0.04,
+    },
+    h2: {
+      mobile: 32,
+      desktop: 72,
+      lineHeight: 1.2,
+      weight: 700,
+      letterSpacing: -0.02,
+    },
+    h3: {
+      mobile: 26,
+      desktop: 48,
+      lineHeight: 1.25,
+      weight: 600,
+      letterSpacing: -0.01,
+    },
+    body: {
+      mobile: 16,
+      desktop: 18,
+      lineHeight: 1.6,
+      weight: 400,
+      letterSpacing: 0,
+    },
+    small: {
+      mobile: 14,
+      desktop: 14,
+      lineHeight: 1.4,
+      weight: 500,
+      letterSpacing: 0,
+    },
+  },
+  spacing: {
+    xs: 4,
+    sm: 8,
+    md: 16,
+    lg: 24,
+    xl: 32,
+    '2xl': 48,
+    '3xl': 64,
+  },
+};
+
+export function pxToRem(px: number): string {
+  return `${(px / 16).toFixed(4)}rem`;
+}
+
+export function buildFluidSize(mobilePx: number, desktopPx: number): string {
+  const minViewport = 320;
+  const maxViewport = 1440;
+  const slope = (desktopPx - mobilePx) / (maxViewport - minViewport);
+  const slopeVW = slope * 100;
+  const interceptPx = mobilePx - slope * minViewport;
+
+  const minRem = (mobilePx / 16).toFixed(4);
+  const maxRem = (desktopPx / 16).toFixed(4);
+  const interceptRem = (interceptPx / 16).toFixed(4);
+  const slopeVWFixed = slopeVW.toFixed(4);
+
+  return `clamp(${minRem}rem, ${interceptRem}rem + ${slopeVWFixed}vw, ${maxRem}rem)`;
+}
+
+export function formatLetterSpacing(value?: number | null): string {
+  if (value === undefined || value === null) {
+    return 'normal';
+  }
+
+  if (value === 0) {
+    return '0em';
+  }
+
+  return `${Number(value.toFixed(3))}em`;
+}
+
+export function ensureFontLibraryIntegrity(library: FontLibraryEntry[]): FontLibraryEntry[] {
+  const map = new Map<string, FontLibraryEntry>();
+  for (const entry of library) {
+    map.set(entry.id, { ...entry });
+  }
+
+  for (const entry of DEFAULT_FONT_LIBRARY) {
+    if (!map.has(entry.id)) {
+      map.set(entry.id, { ...entry });
+    }
+  }
+
+  return Array.from(map.values());
+}
+
+export function getFontById(library: FontLibraryEntry[], id: string): FontLibraryEntry | undefined {
+  return library.find((item) => item.id === id);
+}
+
+export function defaultFallbacksFor(category: FontCategory): string[] {
+  switch (category) {
+    case 'monospace':
+      return ['monospace'];
+    case 'serif':
+      return ['serif'];
+    case 'display':
+    case 'handwriting':
+      return ['"Segoe UI"', 'sans-serif'];
+    default:
+      return ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'sans-serif'];
+  }
+}
+
+export function buildFontStack(entry: FontLibraryEntry): string {
+  const fallbacks = entry.fallbacks.length > 0 ? entry.fallbacks : defaultFallbacksFor(entry.category);
+  return [entry.family, ...fallbacks].join(', ');
+}
+
+export function resolveFontStack(
+  library: FontLibraryEntry[],
+  id: string,
+  fallbackId: string,
+): string {
+  const entry = getFontById(library, id) ?? getFontById(library, fallbackId);
+  if (entry) {
+    return buildFontStack(entry);
+  }
+
+  const fallback = getFontById(DEFAULT_FONT_LIBRARY, fallbackId) ?? DEFAULT_FONT_LIBRARY[0];
+  return buildFontStack(fallback);
+}
+
+export function buildDesignSystemVariableMap(settings: DesignSystemSettings): Record<string, string> {
+  const library = ensureFontLibraryIntegrity(settings.fontLibrary);
+  const headingStack = resolveFontStack(library, settings.fonts.heading, 'manrope');
+  const bodyStack = resolveFontStack(library, settings.fonts.body, 'manrope');
+  const accentStack = resolveFontStack(library, settings.fonts.accent, 'pt-mono');
+
+  const typographyVars: Record<string, string> = {};
+  for (const key of typographyOrder) {
+    const token = settings.typography[key];
+    const variables = TYPOGRAPHY_VARIABLES[key];
+    typographyVars[variables.size] = buildFluidSize(token.mobile, token.desktop);
+    typographyVars[variables.lineHeight] = `${token.lineHeight}`;
+    typographyVars[variables.weight] = `${token.weight}`;
+    typographyVars[variables.letterSpacing] = formatLetterSpacing(token.letterSpacing);
+  }
+
+  const spacingVars: Record<string, string> = {
+    '--ds-spacing-xs': pxToRem(settings.spacing.xs),
+    '--ds-spacing-sm': pxToRem(settings.spacing.sm),
+    '--ds-spacing-md': pxToRem(settings.spacing.md),
+    '--ds-spacing-lg': pxToRem(settings.spacing.lg),
+    '--ds-spacing-xl': pxToRem(settings.spacing.xl),
+    '--ds-spacing-2xl': pxToRem(settings.spacing['2xl']),
+    '--ds-spacing-3xl': pxToRem(settings.spacing['3xl']),
+  };
+
+  const colorVars: Record<string, string> = {
+    '--ds-color-primary': settings.colors.primary,
+    '--ds-color-primary-foreground': settings.colors.primaryForeground,
+    '--ds-color-accent': settings.colors.accent,
+    '--ds-color-accent-foreground': settings.colors.accentForeground,
+    '--ds-color-background': settings.colors.background,
+    '--ds-color-surface': settings.colors.surface,
+    '--ds-color-surface-foreground': settings.colors.surfaceForeground,
+    '--ds-color-border': settings.colors.border,
+    '--ds-color-neutral': settings.colors.neutral,
+    '--ds-color-neutral-foreground': settings.colors.neutralForeground,
+    '--ds-color-muted': settings.colors.muted,
+    '--ds-color-muted-foreground': settings.colors.mutedForeground,
+    '--ds-color-text-primary': settings.colors.textPrimary,
+    '--ds-color-text-secondary': settings.colors.textSecondary,
+    '--ds-color-success': settings.colors.success,
+    '--ds-color-warning': settings.colors.warning,
+    '--ds-color-danger': settings.colors.danger,
+  };
+
+  return {
+    '--ds-font-heading': headingStack,
+    '--ds-font-body': bodyStack,
+    '--ds-font-accent': accentStack,
+    ...typographyVars,
+    ...spacingVars,
+    ...colorVars,
+  };
+}
+
+export function collectFontCssLinks(library: FontLibraryEntry[]): string[] {
+  const seen = new Set<string>();
+  const links: string[] = [];
+
+  for (const entry of ensureFontLibraryIntegrity(library)) {
+    if (entry.cssUrl && !seen.has(entry.cssUrl)) {
+      seen.add(entry.cssUrl);
+      links.push(entry.cssUrl);
+    }
+  }
+
+  return links;
+}
+
+export function slugifyFontId(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40);
+}
+
+export const DEFAULT_FONT_IDS = {
+  heading: 'manrope',
+  body: 'manrope',
+  accent: 'pt-mono',
+};
+

--- a/src/lib/settings/design-system.ts
+++ b/src/lib/settings/design-system.ts
@@ -1,0 +1,245 @@
+import 'server-only';
+
+import { cache } from 'react';
+import { unstable_noStore as noStore } from 'next/cache';
+import prisma from '@/lib/prisma';
+import {
+  DESIGN_SYSTEM_KEY,
+  DEFAULT_DESIGN_SYSTEM_SETTINGS,
+  DEFAULT_FONT_IDS,
+  designSystemPartialSchema,
+  designSystemSchema,
+  type DesignSystemPartial,
+  type DesignSystemSettings,
+  type FontLibraryEntry,
+  ensureFontLibraryIntegrity,
+  spacingOrder,
+  typographyOrder,
+} from './design-system.shared';
+
+export interface DesignSystemSnapshot {
+  settings: DesignSystemSettings;
+  updatedAt: Date | null;
+}
+
+function ensureFontChoice(
+  library: DesignSystemSettings['fontLibrary'],
+  candidate: string | undefined,
+  fallback: string,
+) {
+  if (candidate && library.some((font) => font.id === candidate)) {
+    return candidate;
+  }
+
+  if (library.some((font) => font.id === fallback)) {
+    return fallback;
+  }
+
+  return library[0]?.id ?? fallback;
+}
+
+function sanitizeFontLibrary(
+  entries: DesignSystemPartial['fontLibrary'],
+): FontLibraryEntry[] | null {
+  if (!Array.isArray(entries)) {
+    return null;
+  }
+
+  const validEntries: FontLibraryEntry[] = [];
+
+  for (const entry of entries) {
+    if (
+      entry &&
+      typeof entry.id === 'string' &&
+      typeof entry.name === 'string' &&
+      typeof entry.family === 'string' &&
+      Array.isArray(entry.fallbacks) &&
+      typeof entry.category === 'string'
+    ) {
+      validEntries.push({
+        id: entry.id,
+        name: entry.name,
+        family: entry.family,
+        cssUrl: entry.cssUrl,
+        fallbacks: entry.fallbacks,
+        category: entry.category,
+        previewText: entry.previewText,
+        isSystem: entry.isSystem,
+      });
+    }
+  }
+
+  return validEntries.length > 0 ? validEntries : null;
+}
+
+function mergeWithDefaults(value: DesignSystemPartial | null | undefined): DesignSystemSettings {
+  if (!value) {
+    return structuredClone(DEFAULT_DESIGN_SYSTEM_SETTINGS);
+  }
+
+  const defaults = DEFAULT_DESIGN_SYSTEM_SETTINGS;
+  const userLibrary = sanitizeFontLibrary(value.fontLibrary);
+  const mergedLibrary = ensureFontLibraryIntegrity(userLibrary ?? defaults.fontLibrary);
+
+  const fonts = {
+    heading: ensureFontChoice(mergedLibrary, value.fonts?.heading, DEFAULT_FONT_IDS.heading),
+    body: ensureFontChoice(mergedLibrary, value.fonts?.body, DEFAULT_FONT_IDS.body),
+    accent: ensureFontChoice(mergedLibrary, value.fonts?.accent, DEFAULT_FONT_IDS.accent),
+  } satisfies DesignSystemSettings['fonts'];
+
+  const typography = typographyOrder.reduce((acc, key) => {
+    const fallback = defaults.typography[key];
+    const override = value.typography?.[key];
+
+    acc[key] = {
+      mobile: override?.mobile ?? fallback.mobile,
+      desktop: override?.desktop ?? fallback.desktop,
+      lineHeight: override?.lineHeight ?? fallback.lineHeight,
+      weight: override?.weight ?? fallback.weight,
+      letterSpacing:
+        override?.letterSpacing === undefined
+          ? fallback.letterSpacing
+          : override.letterSpacing,
+    };
+
+    return acc;
+  }, {} as DesignSystemSettings['typography']);
+
+  const spacing = spacingOrder.reduce((acc, key) => {
+    acc[key] = value.spacing?.[key] ?? defaults.spacing[key];
+    return acc;
+  }, {} as DesignSystemSettings['spacing']);
+
+  const colors = Object.keys(defaults.colors).reduce((acc, key) => {
+    const typedKey = key as keyof DesignSystemSettings['colors'];
+    acc[typedKey] = value.colors?.[typedKey] ?? defaults.colors[typedKey];
+    return acc;
+  }, {} as DesignSystemSettings['colors']);
+
+  return {
+    siteName: value.siteName ?? defaults.siteName,
+    colors,
+    fonts,
+    fontLibrary: mergedLibrary,
+    typography,
+    spacing,
+  };
+}
+
+function parseLegacySpacing(value: unknown): number | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+
+  if (trimmed.endsWith('rem')) {
+    const numeric = Number.parseFloat(trimmed.replace('rem', ''));
+    if (Number.isFinite(numeric)) {
+      return Math.round(numeric * 16);
+    }
+    return undefined;
+  }
+
+  if (trimmed.endsWith('px')) {
+    const numeric = Number.parseFloat(trimmed.replace('px', ''));
+    if (Number.isFinite(numeric)) {
+      return Math.round(numeric);
+    }
+    return undefined;
+  }
+
+  const numeric = Number(trimmed);
+  return Number.isFinite(numeric) ? Math.round(numeric) : undefined;
+}
+
+function convertLegacyPayload(raw: unknown): DesignSystemPartial | null {
+  if (typeof raw !== 'object' || raw === null) {
+    return null;
+  }
+
+  const legacy = raw as Record<string, unknown>;
+  const partial: DesignSystemPartial = {};
+
+  if (typeof legacy.siteName === 'string') {
+    partial.siteName = legacy.siteName;
+  }
+
+  if (typeof legacy.spacing === 'object' && legacy.spacing !== null) {
+    partial.spacing = {} as DesignSystemSettings['spacing'];
+    for (const key of spacingOrder) {
+      const parsed = parseLegacySpacing((legacy.spacing as Record<string, unknown>)[key]);
+      if (typeof parsed === 'number') {
+        partial.spacing[key] = parsed;
+      }
+    }
+  }
+
+  return Object.keys(partial).length > 0 ? partial : null;
+}
+
+function normalizeDesignSystemPayload(raw: unknown): DesignSystemSettings {
+  try {
+    const parsed = designSystemPartialSchema.parse(raw);
+    return mergeWithDefaults(parsed);
+  } catch (error) {
+    const legacy = convertLegacyPayload(raw);
+    if (legacy) {
+      return mergeWithDefaults(legacy);
+    }
+    throw error;
+  }
+}
+
+function safeParseSettings(value: string | null): DesignSystemSettings {
+  if (!value) {
+    return structuredClone(DEFAULT_DESIGN_SYSTEM_SETTINGS);
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    return normalizeDesignSystemPayload(parsed);
+  } catch (error) {
+    console.error('[DesignSystem] Failed to parse settings, fallback to defaults', error);
+    return structuredClone(DEFAULT_DESIGN_SYSTEM_SETTINGS);
+  }
+}
+
+export const getDesignSystemSettings = cache(async (): Promise<DesignSystemSnapshot> => {
+  noStore();
+
+  const record = await prisma.systemSetting.findUnique({
+    where: { key: DESIGN_SYSTEM_KEY },
+  });
+
+  const settings = safeParseSettings(record?.value ?? null);
+
+  return {
+    settings,
+    updatedAt: record?.updatedAt ?? null,
+  };
+});
+
+export async function saveDesignSystemSettings(
+  payload: DesignSystemSettings,
+): Promise<DesignSystemSnapshot> {
+  const normalized = designSystemSchema.parse(payload);
+
+  const record = await prisma.systemSetting.upsert({
+    where: { key: DESIGN_SYSTEM_KEY },
+    update: { value: JSON.stringify(normalized) },
+    create: { key: DESIGN_SYSTEM_KEY, value: JSON.stringify(normalized) },
+  });
+
+  return {
+    settings: mergeWithDefaults(normalized),
+    updatedAt: record.updatedAt,
+  };
+}
+
+export function validateDesignSystemPayload(input: unknown): DesignSystemSettings {
+  return designSystemSchema.parse(input);
+}
+
+export { DESIGN_SYSTEM_KEY, DEFAULT_DESIGN_SYSTEM_SETTINGS };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -24,21 +24,52 @@ const config: Config = {
     extend: {
       // "Фирменная палитра"
       colors: {
-        brand: { lilac: '#6B80C5', 'lilac-light': '#C1D0FF' },
-        accent: {
-          pink: '#C1D0FF',
-          'pink-light': '#FBC0E3',
-          'pink-pale': '#FFE1F3',
+        brand: {
+          lilac: 'var(--ds-color-primary)',
+          'lilac-light': 'var(--ds-color-accent)',
         },
-        feedback: { error: '#E06F6F', red: '#D32F2F' },
-        text: { primary: '#272727', secondary: '#6B80C5' },
-        background: { primary: '#FFFFFF', secondary: '#FFE1F3' },
+        accent: {
+          pink: 'var(--ds-color-accent)',
+          'pink-light': 'var(--ds-color-surface)',
+          'pink-pale': 'var(--ds-color-muted)',
+        },
+        feedback: {
+          error: 'var(--ds-color-danger)',
+          red: 'var(--ds-color-danger)',
+          success: 'var(--ds-color-success)',
+          warning: 'var(--ds-color-warning)',
+        },
+        text: {
+          primary: 'var(--ds-color-text-primary)',
+          secondary: 'var(--ds-color-text-secondary)',
+          muted: 'var(--ds-color-muted-foreground)',
+        },
+        background: {
+          primary: 'var(--ds-color-background)',
+          secondary: 'var(--ds-color-surface)',
+        },
+        border: {
+          DEFAULT: 'var(--ds-color-border)',
+          neutral: 'var(--ds-color-neutral)',
+        },
+        ds: {
+          primary: 'var(--ds-color-primary)',
+          'primary-foreground': 'var(--ds-color-primary-foreground)',
+          accent: 'var(--ds-color-accent)',
+          'accent-foreground': 'var(--ds-color-accent-foreground)',
+          surface: 'var(--ds-color-surface)',
+          'surface-foreground': 'var(--ds-color-surface-foreground)',
+          neutral: 'var(--ds-color-neutral)',
+          'neutral-foreground': 'var(--ds-color-neutral-foreground)',
+          muted: 'var(--ds-color-muted)',
+          'muted-foreground': 'var(--ds-color-muted-foreground)',
+        },
       },
       // "Набор фирменных шрифтов"
       fontFamily: {
-        heading: ['var(--font-heading)', 'sans-serif'],
-        body: ['var(--font-body)', 'sans-serif'],
-        mono: ['var(--font-mono)', 'monospace'],
+        heading: ['var(--ds-font-heading, var(--font-heading))', 'sans-serif'],
+        body: ['var(--ds-font-body, var(--font-body))', 'sans-serif'],
+        mono: ['var(--ds-font-accent, var(--font-mono))', 'monospace'],
       },
       // "Типографика"
       fontSize: {
@@ -47,6 +78,55 @@ const config: Config = {
           'clamp(0.8rem, 3vw, 1.25rem)',
           { lineHeight: '1.2' },
         ],
+        'ds-h1': [
+          'var(--ds-heading-1-size)',
+          {
+            lineHeight: 'var(--ds-heading-1-line-height)',
+            letterSpacing: 'var(--ds-heading-1-letter-spacing, -0.03em)',
+            fontWeight: 'var(--ds-heading-1-weight)',
+          },
+        ],
+        'ds-h2': [
+          'var(--ds-heading-2-size)',
+          {
+            lineHeight: 'var(--ds-heading-2-line-height)',
+            letterSpacing: 'var(--ds-heading-2-letter-spacing, -0.02em)',
+            fontWeight: 'var(--ds-heading-2-weight)',
+          },
+        ],
+        'ds-h3': [
+          'var(--ds-heading-3-size)',
+          {
+            lineHeight: 'var(--ds-heading-3-line-height)',
+            letterSpacing: 'var(--ds-heading-3-letter-spacing, 0)',
+            fontWeight: 'var(--ds-heading-3-weight)',
+          },
+        ],
+        'ds-body': [
+          'var(--ds-body-font-size)',
+          {
+            lineHeight: 'var(--ds-body-line-height)',
+            letterSpacing: 'var(--ds-body-letter-spacing, 0)',
+            fontWeight: 'var(--ds-body-font-weight)',
+          },
+        ],
+        'ds-small': [
+          'var(--ds-small-font-size)',
+          {
+            lineHeight: 'var(--ds-small-line-height)',
+            letterSpacing: 'var(--ds-small-letter-spacing, 0)',
+            fontWeight: 'var(--ds-small-font-weight)',
+          },
+        ],
+      },
+      spacing: {
+        'ds-xs': 'var(--ds-spacing-xs)',
+        'ds-sm': 'var(--ds-spacing-sm)',
+        'ds-md': 'var(--ds-spacing-md)',
+        'ds-lg': 'var(--ds-spacing-lg)',
+        'ds-xl': 'var(--ds-spacing-xl)',
+        'ds-2xl': 'var(--ds-spacing-2xl)',
+        'ds-3xl': 'var(--ds-spacing-3xl)',
       },
       typographyStyles: ({ theme }: { theme: any }) => ({
         h1: {


### PR DESCRIPTION
## Summary
- add a shared design-system schema with color tokens, font library support, and updated defaults for typography and spacing
- update persistence, Tailwind, and app layout to emit CSS variables, auto-load selected fonts, and expose the new palette
- rebuild the admin design system editor with Google Fonts import, color management, spacing sliders, and an icon catalog preview

## Testing
- `npm run lint` *(fails: Next.js prompts for interactive ESLint setup in this environment)*
- `npm run build` *(fails: Prisma requires DATABASE_URL for schema validation in this environment)*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68e595ac629083319d40e736258a2e8b