### PR TITLE
Fix TypeScript predicate for icon registry

### DIFF
--- a/src/components/admin/settings/DesignSystemForm.tsx
+++ b/src/components/admin/settings/DesignSystemForm.tsx
@@ -112,7 +112,7 @@ export default function DesignSystemForm({
 
   const iconEntries = useMemo(() => {
     return Object.entries(sharedIcons)
-      .filter((entry): entry is [string, ComponentType<Record<string, any>>] => {
+      .filter((entry): entry is [string, ComponentType<any>] => {
         const [, component] = entry;
         return typeof component === 'function';
       })


### PR DESCRIPTION
## Summary
- relax the icon entry type predicate in the design system form to accept any component type and restore type compatibility during the build

## Testing
- npm run build *(fails: Prisma schema validation error because DATABASE_URL is not set in the local environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5a8dbf57c83318c923187568b4a65